### PR TITLE
Expose product_common's WASM bindings

### DIFF
--- a/bindings/wasm/iota_interaction_ts/src/error.rs
+++ b/bindings/wasm/iota_interaction_ts/src/error.rs
@@ -173,6 +173,15 @@ impl From<anyhow::Error> for WasmError<'_> {
   }
 }
 
+impl From<bcs::Error> for WasmError<'_> {
+  fn from(error: bcs::Error) -> Self {
+    Self {
+      name: Cow::Borrowed("BCS"),
+      message: Cow::Owned(error.to_string()),
+    }
+  }
+}
+
 /// Consumes the struct and returns a Result<_, String>, leaving an `Ok` value untouched.
 pub fn stringify_js_error<T>(result: Result<T>) -> StdResult<T, String> {
   result.map_err(|js_value| {

--- a/product_common/Cargo.toml
+++ b/product_common/Cargo.toml
@@ -14,7 +14,9 @@ description = "Sources shared by IOTA products."
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
+bcs = { workspace = true, optional = true }
 cfg-if.workspace = true
+fastcrypto = { workspace = true, optional = true }
 iota-keys = { git = "https://github.com/iotaledger/iota.git", package = "iota-keys", tag = "v0.12.0-rc", optional = true }
 itertools = { version = "0.13.0", optional = true }
 lazy_static = { version = "1.5.0", optional = true }
@@ -25,8 +27,6 @@ serde_json.workspace = true
 strum.workspace = true
 thiserror.workspace = true
 toml = "0.8"
-bcs = { workspace = true, optional = true }
-fastcrypto = { workspace = true, optional = true }
 
 [dependencies.identity_jose]
 git = "https://github.com/iotaledger/identity.rs.git"
@@ -35,9 +35,7 @@ package = "identity_jose"
 optional = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iota_interaction = { version = "=1.6.0-alpha", path = "../iota_interaction", features = [
-  "keytool",
-] }
+iota_interaction = { version = "=1.6.0-alpha", path = "../iota_interaction", features = ["keytool"] }
 iota_interaction_rust = { version = "=1.6.0-alpha", path = "../iota_interaction_rust", optional = true }
 iota-sdk.workspace = true
 tokio = { version = "1", default-features = false, features = ["process"] }

--- a/product_common/Cargo.toml
+++ b/product_common/Cargo.toml
@@ -25,6 +25,8 @@ serde_json.workspace = true
 strum.workspace = true
 thiserror.workspace = true
 toml = "0.8"
+bcs = { workspace = true, optional = true }
+fastcrypto = { workspace = true, optional = true }
 
 [dependencies.identity_jose]
 git = "https://github.com/iotaledger/identity.rs.git"
@@ -33,16 +35,19 @@ package = "identity_jose"
 optional = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iota_interaction = { version = "=1.6.0-alpha", path = "../iota_interaction", features = ["keytool"] }
+iota_interaction = { version = "=1.6.0-alpha", path = "../iota_interaction", features = [
+  "keytool",
+] }
 iota_interaction_rust = { version = "=1.6.0-alpha", path = "../iota_interaction_rust", optional = true }
 iota-sdk.workspace = true
 tokio = { version = "1", default-features = false, features = ["process"] }
-bcs = { workspace = true, optional = true }
-fastcrypto = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 iota_interaction = { version = "=1.6.0-alpha", path = "../iota_interaction", default-features = false }
 iota_interaction_ts = { version = "=1.6.0-alpha", path = "../bindings/wasm/iota_interaction_ts" }
+wasm-bindgen = { version = "0.2.100", optional = true }
+wasm-bindgen-futures = { version = "0.4", default-features = false, optional = true }
+js-sys = { version = "0.3", optional = true }
 
 [dev-dependencies]
 iota_interaction = { version = "=1.6.0-alpha", path = "../iota_interaction" }
@@ -51,6 +56,13 @@ iota_interaction_rust = { version = "=1.6.0-alpha", path = "../iota_interaction_
 [features]
 default = []
 send-sync = ["secret-storage/send-sync-storage"]
+bindings = [
+  "dep:wasm-bindgen",
+  "dep:wasm-bindgen-futures",
+  "dep:js-sys",
+  "dep:bcs",
+  "dep:fastcrypto",
+]
 test-utils = [
   "dep:identity_jose",
   "dep:lazy_static",

--- a/product_common/src/bindings/core_client.rs
+++ b/product_common/src/bindings/core_client.rs
@@ -1,0 +1,206 @@
+// Copyright 2020-2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_interaction::types::base_types::{IotaAddress, ObjectID, ObjectIDParseError};
+use iota_interaction::types::crypto::PublicKey;
+use iota_interaction_ts::bindings::{WasmIotaClient, WasmTransactionSigner};
+use iota_interaction_ts::core_client::{WasmCoreClient, WasmCoreClientReadOnly};
+use iota_interaction_ts::error::{Result, WasmResult};
+use iota_interaction_ts::{IotaClientAdapter, WasmPublicKey};
+use wasm_bindgen::prelude::*;
+
+use crate::core_client::{CoreClient, CoreClientReadOnly};
+use crate::network_name::NetworkName;
+
+#[derive(Clone)]
+#[wasm_bindgen]
+pub struct WasmManagedCoreClientReadOnly {
+  package_id: ObjectID,
+  network: NetworkName,
+  iota_client_adapter: IotaClientAdapter,
+}
+
+impl WasmManagedCoreClientReadOnly {
+  pub fn from_wasm(wasm_core_client: &WasmCoreClientReadOnly) -> Result<Self> {
+    let package_id = wasm_core_client
+      .package_id()
+      .parse()
+      .map_err(|e: ObjectIDParseError| JsError::new(&e.to_string()))?;
+    let network = wasm_core_client.network().parse().wasm_result()?;
+    let iota_client_adapter = IotaClientAdapter::new(wasm_core_client.iota_client());
+
+    Ok(Self {
+      package_id,
+      network,
+      iota_client_adapter,
+    })
+  }
+
+  pub fn into_wasm(self) -> WasmCoreClientReadOnly {
+    JsValue::from(self).unchecked_into()
+  }
+
+  pub fn from_rust<C>(core_client: &C) -> Self
+  where
+    C: CoreClientReadOnly,
+  {
+    let package_id = core_client.package_id();
+    let network = core_client.network_name().clone();
+    let iota_client_adapter = core_client.client_adapter().clone();
+
+    Self {
+      package_id,
+      network,
+      iota_client_adapter,
+    }
+  }
+}
+
+#[wasm_bindgen]
+impl WasmManagedCoreClientReadOnly {
+  // Ensure the TS CoreClientReadOnly interface is exposed.
+
+  #[wasm_bindgen(js_name = packageId)]
+  pub fn package_id(&self) -> String {
+    self.package_id.to_string()
+  }
+
+  #[wasm_bindgen]
+  pub fn network(&self) -> String {
+    self.network.to_string()
+  }
+
+  #[wasm_bindgen(js_name = iotaClient)]
+  pub fn iota_client(&self) -> WasmIotaClient {
+    self.iota_client_adapter.clone().into_inner()
+  }
+}
+
+impl CoreClientReadOnly for WasmManagedCoreClientReadOnly {
+  fn package_id(&self) -> ObjectID {
+    self.package_id
+  }
+
+  fn network_name(&self) -> &NetworkName {
+    &self.network
+  }
+
+  fn client_adapter(&self) -> &IotaClientAdapter {
+    &self.iota_client_adapter
+  }
+}
+
+#[wasm_bindgen]
+pub struct WasmManagedCoreClient {
+  signer: WasmTransactionSigner,
+  sender_address: IotaAddress,
+  public_key: PublicKey,
+  read_only: WasmManagedCoreClientReadOnly,
+}
+
+impl AsRef<WasmManagedCoreClientReadOnly> for WasmManagedCoreClient {
+  fn as_ref(&self) -> &WasmManagedCoreClientReadOnly {
+    &self.read_only
+  }
+}
+
+impl WasmManagedCoreClient {
+  pub fn from_wasm(wasm_core_client: &WasmCoreClient) -> Result<Self> {
+    let signer = wasm_core_client.signer();
+    let sender_address = wasm_core_client.sender_address().parse().wasm_result()?;
+    let public_key = wasm_core_client.sender_public_key().try_into()?;
+    let read_only = WasmManagedCoreClientReadOnly::from_wasm(wasm_core_client.as_ref())?;
+
+    Ok(Self {
+      read_only,
+      signer,
+      sender_address,
+      public_key,
+    })
+  }
+
+  // Note: we don't have any use for this, but will be needed when a duck typed interface will
+  // require a CoreClient<S>.
+  #[allow(dead_code)]
+  pub fn from_rust<C>(core_client: &C) -> Self
+  where
+    C: CoreClient<WasmTransactionSigner>,
+  {
+    let read_only = WasmManagedCoreClientReadOnly::from_rust(core_client);
+    let signer = core_client.signer().clone();
+    let sender_address = core_client.sender_address();
+    let public_key = core_client.sender_public_key().clone();
+
+    Self {
+      read_only,
+      signer,
+      sender_address,
+      public_key,
+    }
+  }
+}
+
+#[wasm_bindgen]
+impl WasmManagedCoreClient {
+  // Ensure TS CoreClientReadOnly interface is exposed.
+
+  #[wasm_bindgen(js_name = packageId)]
+  pub fn package_id(&self) -> String {
+    self.read_only.package_id.to_string()
+  }
+
+  #[wasm_bindgen]
+  pub fn network(&self) -> String {
+    self.read_only.network.to_string()
+  }
+
+  #[wasm_bindgen(js_name = iotaClient)]
+  pub fn iota_client(&self) -> WasmIotaClient {
+    self.read_only.iota_client_adapter.clone().into_inner()
+  }
+
+  // Ensure TS CoreClient interface is exposed.
+
+  #[wasm_bindgen]
+  pub fn signer(&self) -> WasmTransactionSigner {
+    self.signer.clone()
+  }
+
+  #[wasm_bindgen(js_name = senderAddress)]
+  pub fn sender_address(&self) -> String {
+    self.sender_address.to_string()
+  }
+
+  #[wasm_bindgen(js_name = senderPublicKey)]
+  pub fn sender_public_key(&self) -> Result<WasmPublicKey> {
+    WasmPublicKey::try_from(&self.public_key)
+  }
+}
+
+impl CoreClientReadOnly for WasmManagedCoreClient {
+  fn package_id(&self) -> ObjectID {
+    self.read_only.package_id
+  }
+
+  fn network_name(&self) -> &NetworkName {
+    &self.read_only.network
+  }
+
+  fn client_adapter(&self) -> &IotaClientAdapter {
+    &self.read_only.iota_client_adapter
+  }
+}
+
+impl CoreClient<WasmTransactionSigner> for WasmManagedCoreClient {
+  fn sender_address(&self) -> IotaAddress {
+    self.sender_address
+  }
+
+  fn sender_public_key(&self) -> &PublicKey {
+    &self.public_key
+  }
+
+  fn signer(&self) -> &WasmTransactionSigner {
+    &self.signer
+  }
+}

--- a/product_common/src/bindings/mod.rs
+++ b/product_common/src/bindings/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2020-2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(feature = "core-client")]
+pub mod core_client;
+#[cfg(feature = "transaction")]
+pub mod transaction;
+
+use iota_interaction_ts::error::WasmError;
+
+impl From<crate::Error> for WasmError<'static> {
+  fn from(e: crate::Error) -> Self {
+    WasmError::new("product-common".into(), e.to_string().into())
+  }
+}

--- a/product_common/src/bindings/transaction.rs
+++ b/product_common/src/bindings/transaction.rs
@@ -1,0 +1,235 @@
+// Copyright 2020-2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::result::Result as StdResult;
+
+use anyhow::{anyhow, Context as _};
+use async_trait::async_trait;
+use fastcrypto::traits::EncodeDecodeBase64;
+use iota_interaction::rpc_types::IotaTransactionBlockEffects;
+use iota_interaction::types::crypto::Signature;
+use iota_interaction::types::transaction::{ProgrammableTransaction, TransactionData, TransactionDataAPI as _};
+use iota_interaction_ts::bindings::{
+  WasmIotaTransactionBlockEffects, WasmIotaTransactionBlockResponse, WasmObjectRef, WasmTransactionDataBuilder,
+};
+use iota_interaction_ts::core_client::{WasmCoreClient, WasmCoreClientReadOnly};
+use iota_interaction_ts::error::{Result, WasmResult as _};
+use js_sys::JsString;
+use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::{JsCast as _, JsValue};
+use wasm_bindgen_futures::JsFuture;
+
+use crate::bindings::core_client::{WasmManagedCoreClient, WasmManagedCoreClientReadOnly};
+use crate::core_client::CoreClientReadOnly;
+use crate::transaction::transaction_builder::{MutGasDataRef, Transaction, TransactionBuilder};
+use crate::transaction::TransactionOutputInternal;
+
+#[wasm_bindgen]
+extern "C" {
+  #[derive(Clone)]
+  #[wasm_bindgen(typescript_type = "Transaction<unknown>")]
+  pub type WasmTransaction;
+
+  #[wasm_bindgen(method, catch, js_name = buildProgrammableTransaction)]
+  pub async fn build_programmable_transaction(
+    this: &WasmTransaction,
+    client: &WasmCoreClientReadOnly,
+  ) -> Result<js_sys::Uint8Array>;
+  #[wasm_bindgen(method, catch)]
+  pub async fn apply(
+    this: &WasmTransaction,
+    effects: &WasmIotaTransactionBlockEffects,
+    client: &WasmCoreClientReadOnly,
+  ) -> Result<JsValue>;
+}
+
+#[async_trait(?Send)]
+impl Transaction for WasmTransaction {
+  type Output = JsValue;
+  type Error = crate::Error;
+
+  async fn build_programmable_transaction<C>(&self, client: &C) -> StdResult<ProgrammableTransaction, Self::Error>
+  where
+    C: CoreClientReadOnly,
+  {
+    let managed_client = WasmManagedCoreClientReadOnly::from_rust(client);
+    let core_client = managed_client.into_wasm();
+    let pt_bcs = Self::build_programmable_transaction(self, &core_client)
+      .await
+      .map_err(|e| {
+        crate::Error::TransactionBuildingFailed(format!("failed to build programmable transaction from WASM: {e:?}"))
+      })?
+      .to_vec();
+
+    bcs::from_bytes(&pt_bcs).map_err(|e| crate::Error::TransactionBuildingFailed(e.to_string()))
+  }
+
+  async fn apply<C>(self, effects: &mut IotaTransactionBlockEffects, client: &C) -> StdResult<Self::Output, Self::Error>
+  where
+    C: CoreClientReadOnly,
+  {
+    let managed_client = WasmManagedCoreClientReadOnly::from_rust(client);
+    let core_client = managed_client.into_wasm();
+    let wasm_effects = WasmIotaTransactionBlockEffects::from(&*effects);
+
+    Self::apply(&self, &wasm_effects, &core_client)
+      .await
+      .map_err(|e| crate::Error::Transaction(anyhow!("failed to apply effects from WASM Transaction: {e:?}").into()))
+  }
+}
+
+#[wasm_bindgen(js_name = TransactionBuilder, skip_typescript)]
+pub struct WasmTransactionBuilder(pub(crate) TransactionBuilder<WasmTransaction>);
+
+#[wasm_bindgen(js_class = TransactionBuilder)]
+impl WasmTransactionBuilder {
+  #[wasm_bindgen(constructor)]
+  pub fn new(tx: WasmTransaction) -> Self {
+    Self(TransactionBuilder::new(tx))
+  }
+
+  #[wasm_bindgen(getter)]
+  pub fn transaction(&self) -> WasmTransaction {
+    self.0.as_ref().clone()
+  }
+
+  #[wasm_bindgen(js_name = withGasPrice)]
+  pub fn with_gas_price(mut self, price: u64) -> Self {
+    self.0 = self.0.with_gas_price(price);
+    self
+  }
+
+  #[wasm_bindgen(js_name = withGasBudget)]
+  pub fn with_gas_budget(mut self, budget: u64) -> Self {
+    self.0 = self.0.with_gas_budget(budget);
+    self
+  }
+
+  #[wasm_bindgen(js_name = withGasOwner)]
+  pub fn with_gas_owner(mut self, owner: &str) -> Result<Self> {
+    let owner = owner.parse().wasm_result()?;
+    self.0 = self.0.with_gas_owner(owner);
+    Ok(self)
+  }
+
+  #[wasm_bindgen(js_name = withGasPayment)]
+  pub fn with_gas_payment(mut self, payment: Vec<WasmObjectRef>) -> Result<Self> {
+    let payment = payment
+      .into_iter()
+      .map(TryInto::try_into)
+      .collect::<anyhow::Result<Vec<_>>>()
+      .wasm_result()?;
+
+    self.0 = self.0.with_gas_payment(payment);
+    Ok(self)
+  }
+
+  #[wasm_bindgen(js_name = withSender)]
+  pub fn with_sender(mut self, sender: &str) -> Result<Self> {
+    let sender = sender
+      .parse()
+      .map_err(|e| anyhow!("failed to parse IotaAddress: {e}"))
+      .wasm_result()?;
+    self.0 = self.0.with_sender(sender);
+    Ok(self)
+  }
+
+  #[wasm_bindgen(js_name = withSignature)]
+  pub async fn with_signature(mut self, client: &WasmCoreClient) -> Result<Self> {
+    let managed_client = WasmManagedCoreClient::from_wasm(client)?;
+    self.0 = self.0.with_signature(&managed_client).await.wasm_result()?;
+    Ok(self)
+  }
+
+  #[wasm_bindgen(js_name = withSponsor)]
+  pub async fn with_sponsor(
+    mut self,
+    client: &WasmCoreClientReadOnly,
+    #[wasm_bindgen(unchecked_param_type = "SponsorFn")] sponsor_fn: &js_sys::Function,
+  ) -> Result<Self> {
+    let closure = async |mut tx_data_ref: MutGasDataRef<'_>| -> anyhow::Result<Signature> {
+      let tx_data_bcs = bcs::to_bytes(&*tx_data_ref)?;
+      let wasm_tx = WasmTransactionDataBuilder::from_bcs_bytes(js_sys::Uint8Array::from(tx_data_bcs.as_slice()))
+        .map_err(|_| anyhow!("failed to convert TransactionData into JS IotaTransaction"))?;
+      let promise: js_sys::Promise = sponsor_fn
+        .call1(&JsValue::NULL, &wasm_tx)
+        .and_then(|value| value.dyn_into())
+        .map_err(|_| anyhow!("failed to call JS closure"))?;
+      let sig_str: JsString = JsFuture::from(promise)
+        .await
+        .and_then(|value| value.dyn_into())
+        .map_err(|_| anyhow!("failed to build a Future from a JS Promise"))?;
+
+      let modified_tx_data_bcs = wasm_tx
+        .build()
+        .map_err(|_| anyhow!("failed to build JS TransactionDataBuilder"))?
+        .to_vec();
+      let tx_data = bcs::from_bytes::<TransactionData>(&modified_tx_data_bcs)?;
+
+      *tx_data_ref.gas_data_mut() = tx_data.gas_data().clone();
+      let signature = Signature::decode_base64(&String::from(sig_str)).context("failed to decode b64 signature")?;
+
+      Ok(signature)
+    };
+
+    let managed_client = WasmManagedCoreClientReadOnly::from_wasm(client)?;
+    self.0 = self.0.with_sponsor(&managed_client, closure).await.wasm_result()?;
+    Ok(self)
+  }
+
+  #[wasm_bindgen(unchecked_return_type = "[Uint8Array, string[], Transaction]")]
+  pub async fn build(self, client: &WasmCoreClient) -> Result<JsValue> {
+    let managed_client = WasmManagedCoreClient::from_wasm(client)?;
+    let (tx_data, signatures, inner_tx) = self.0.build(&managed_client).await.wasm_result()?;
+    let tx_data_bcs = bcs::to_bytes(&tx_data)
+      .wasm_result()
+      .map(|bcs_bytes| js_sys::Uint8Array::from(bcs_bytes.as_slice()))?;
+    let wasm_signatures = {
+      let wasm_signatures = js_sys::Array::new();
+      for sig in signatures {
+        let b64_sig = sig.encode_base64();
+        wasm_signatures.push(&JsValue::from_str(&b64_sig));
+      }
+
+      wasm_signatures
+    };
+
+    let wasm_triple = js_sys::Array::new();
+    wasm_triple.push(&tx_data_bcs);
+    wasm_triple.push(wasm_signatures.as_ref());
+    wasm_triple.push(inner_tx.as_ref());
+
+    Ok(wasm_triple.into())
+  }
+
+  #[wasm_bindgen(js_name = buildAndExecute, unchecked_return_type = "TransactionOutput<unknown>")]
+  pub async fn build_and_execute(self, client: &WasmCoreClient) -> Result<WasmTransactionOutput> {
+    let managed_client = WasmManagedCoreClient::from_wasm(client)?;
+    self
+      .0
+      .build_and_execute(&managed_client)
+      .await
+      .wasm_result()
+      .map(Into::into)
+  }
+}
+
+#[wasm_bindgen(
+  js_name = TransactionOutput,
+  skip_typescript,
+  inspectable,
+  getter_with_clone
+)]
+pub struct WasmTransactionOutput {
+  pub output: JsValue,
+  pub response: WasmIotaTransactionBlockResponse,
+}
+
+impl From<TransactionOutputInternal<JsValue>> for WasmTransactionOutput {
+  fn from(value: TransactionOutputInternal<JsValue>) -> Self {
+    Self {
+      output: value.output,
+      response: value.response.clone_native_response().response(),
+    }
+  }
+}

--- a/product_common/src/lib.rs
+++ b/product_common/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright 2020-2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(all(feature = "bindings", target_arch = "wasm32"))]
+pub mod bindings;
 #[cfg(feature = "core-client")]
 pub mod core_client;
 pub mod error;

--- a/product_common/src/package_registry.rs
+++ b/product_common/src/package_registry.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 
 use anyhow::Context;
-use iota_sdk::types::base_types::ObjectID;
+use iota_interaction::types::base_types::ObjectID;
 use serde::{Deserialize, Deserializer, Serialize};
 
 pub const MAINNET_CHAIN_ID: &str = "6364aad5";


### PR DESCRIPTION
# Description of change
Adds WASM bindings for stuff in product_common, exposing them through the `bindings` module that gets enabled by the "bindings" feature.

## Links to any relevant issues
Closes issue #21 
