### PR TITLE
Make sure WASM CoreClientReadOnly overrides package_history

### DIFF
--- a/bindings/wasm/iota_interaction_ts/lib/core_client.ts
+++ b/bindings/wasm/iota_interaction_ts/lib/core_client.ts
@@ -4,6 +4,7 @@ import { TransactionSigner } from "~iota_interaction_ts";
 
 export interface CoreClientReadOnly {
     packageId(): string;
+    packageHistory(): string[];
     network(): string;
     iotaClient(): IotaClient;
 }

--- a/bindings/wasm/iota_interaction_ts/src/core_client.rs
+++ b/bindings/wasm/iota_interaction_ts/src/core_client.rs
@@ -15,6 +15,9 @@ extern "C" {
   #[wasm_bindgen(method, js_name = packageId)]
   pub fn package_id(this: &WasmCoreClientReadOnly) -> String;
 
+  #[wasm_bindgen(method, js_name = packageHistory)]
+  pub fn package_history(this: &WasmCoreClientReadOnly) -> Vec<String>;
+
   #[wasm_bindgen(method, js_name = network)]
   pub fn network(this: &WasmCoreClientReadOnly) -> String;
 


### PR DESCRIPTION
# Description of change
`WasmManagedCoreClient[ReadOnly]` should override CoreClientReadOnly::package_history if the ducktyped Client it is created from overrides it.