### PR TITLE
Add trait `IntoTransaction`

### DIFF
--- a/product_common/src/transaction/mod.rs
+++ b/product_common/src/transaction/mod.rs
@@ -75,3 +75,26 @@ where
     self
   }
 }
+
+/// Types that can be turned into a [Transaction].
+pub trait IntoTransaction {
+  /// The transaction this type can be turned into.
+  type Tx: Transaction;
+
+  /// Consume this type into [IntoTransaction::Tx].
+  fn into_transaction(self) -> Self::Tx;
+}
+
+impl<T: Transaction> IntoTransaction for T {
+  type Tx = T;
+  fn into_transaction(self) -> Self::Tx {
+    self
+  }
+}
+
+impl<T: Transaction> IntoTransaction for TransactionBuilder<T> {
+  type Tx = T;
+  fn into_transaction(self) -> Self::Tx {
+    self.into_inner()
+  }
+}

--- a/product_common/src/transaction/transaction_builder.rs
+++ b/product_common/src/transaction/transaction_builder.rs
@@ -178,18 +178,6 @@ impl<Tx> TransactionBuilder<Tx>
 where
   Tx: Transaction + OptionalSend,
 {
-  /// Starts the creation of an executable transaction by supplying
-  /// a type implementing [Transaction].
-  pub fn new(effect: Tx) -> Self {
-    Self {
-      tx: effect,
-      gas: PartialGasData::default(),
-      signatures: vec![],
-      sender: None,
-      programmable_tx: None,
-    }
-  }
-
   async fn transaction_data<C>(&mut self, client: &C) -> anyhow::Result<TransactionData>
   where
     C: CoreClientReadOnly + OptionalSync,
@@ -456,6 +444,17 @@ where
 }
 
 impl<Tx> TransactionBuilder<Tx> {
+  /// Returns a new [TransactionBuilder], wrapping the provided `tx`.
+  pub fn new(tx: Tx) -> Self {
+    Self {
+      tx,
+      gas: PartialGasData::default(),
+      signatures: vec![],
+      sender: None,
+      programmable_tx: None,
+    }
+  }
+
   /// Returns the partial [Transaction] wrapped by this builder, consuming it.
   pub fn into_inner(self) -> Tx {
     self.tx


### PR DESCRIPTION
# Description of change
Introduces a new trait `IntoTransaction` that allows implementing types to be turned into `Transaction`.

APIs that require a `Transaction` can use this trait to be more generic over the type of their argument.
