### PR TITLE
IOTA v1.5.0 upstream merge

### DIFF
--- a/.github/workflows/wasm-retag-npm.yml
+++ b/.github/workflows/wasm-retag-npm.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to set'
+        description: "Tag to set"
         required: true
       version:
-        description: 'version to set'
+        description: "version to set"
         required: true
 
 jobs:
@@ -18,8 +18,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "20.x"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Run dist-tag
         shell: sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1.88"
 bcs = "0.1.6"
 cfg-if = "1.0.0"
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto" }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.4.1" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.5.0-rc" }
 phf = { version = "0.11.2", features = ["macros"] }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.3.0" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1.88"
 bcs = "0.1.6"
 cfg-if = "1.0.0"
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto" }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.5.0-rc" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.5.0" }
 phf = { version = "0.11.2", features = ["macros"] }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.3.0" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }

--- a/iota_interaction/Cargo.toml
+++ b/iota_interaction/Cargo.toml
@@ -22,13 +22,13 @@ jsonpath-rust = { version = "0.5.1", optional = true }
 secret-storage.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-shared-crypto = { git = "https://github.com/iotaledger/iota.git", package = "shared-crypto", tag = "v1.4.1" }
+shared-crypto = { git = "https://github.com/iotaledger/iota.git", package = "shared-crypto", tag = "v1.5.0-rc" }
 strum.workspace = true
 thiserror.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.4.1" }
-move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.4.1" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.5.0-rc" }
+move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.5.0-rc" }
 tokio = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/iota_interaction/Cargo.toml
+++ b/iota_interaction/Cargo.toml
@@ -22,13 +22,13 @@ jsonpath-rust = { version = "0.5.1", optional = true }
 secret-storage.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-shared-crypto = { git = "https://github.com/iotaledger/iota.git", package = "shared-crypto", tag = "v1.5.0-rc" }
+shared-crypto = { git = "https://github.com/iotaledger/iota.git", package = "shared-crypto", tag = "v1.5.0" }
 strum.workspace = true
 thiserror.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.5.0-rc" }
-move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.5.0-rc" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.5.0" }
+move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.5.0" }
 tokio = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/product_common/Cargo.toml
+++ b/product_common/Cargo.toml
@@ -17,7 +17,7 @@ async-trait.workspace = true
 bcs = { workspace = true, optional = true }
 cfg-if.workspace = true
 fastcrypto = { workspace = true, optional = true }
-iota-keys = { git = "https://github.com/iotaledger/iota.git", package = "iota-keys", tag = "v1.4.1", optional = true }
+iota-keys = { git = "https://github.com/iotaledger/iota.git", package = "iota-keys", tag = "v1.5.0-rc", optional = true }
 itertools = { version = "0.13.0", optional = true }
 lazy_static = { version = "1.5.0", optional = true }
 phf.workspace = true

--- a/product_common/Cargo.toml
+++ b/product_common/Cargo.toml
@@ -17,7 +17,7 @@ async-trait.workspace = true
 bcs = { workspace = true, optional = true }
 cfg-if.workspace = true
 fastcrypto = { workspace = true, optional = true }
-iota-keys = { git = "https://github.com/iotaledger/iota.git", package = "iota-keys", tag = "v1.5.0-rc", optional = true }
+iota-keys = { git = "https://github.com/iotaledger/iota.git", package = "iota-keys", tag = "v1.5.0", optional = true }
 itertools = { version = "0.13.0", optional = true }
 lazy_static = { version = "1.5.0", optional = true }
 phf.workspace = true


### PR DESCRIPTION
# Description of change

* Pin all `iota.git` dependencies to tag = "v1.5.0"
* `tokio` and `fastcrypto` dependencies have not been changed
* Upstream merge of IOTA types for `iota_interaction/src/sdk_types`: No changes impacting used functionality

## Links to any relevant issues

fixes #57

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

The changes have been tested using IOTA version "v1.5.0-rc" with the following test PRs:
* Identity: [IOTA v1.5.0-rc - Test with product core feature branch #1712](https://github.com/iotaledger/identity/pull/1712)
* Notarization: [IOTA v1.5.0-rc - Test with product core feature branch #120](https://github.com/iotaledger/notarization/pull/120)
