### PR TITLE
Configure Git for long paths on Windows in CI workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -94,6 +94,10 @@ jobs:
         }}
 
     steps:
+      - name: git configure long path
+        if: matrix.os == 'windows-latest'
+        run: git config --global core.longpaths true
+
       - uses: actions/checkout@v3
 
       - name: Ensure, OpenSSL is available in Windows


### PR DESCRIPTION
# Description of change

CI test fix as been used in other repositories integrated here to configure Git for long paths on Windows in CI workflows