### PR TITLE
Upstream merge to iota v1.7.0-rc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1.88"
 bcs = "0.1.6"
 cfg-if = "1.0.0"
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto" }
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.6.1" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.7.0-rc" }
 phf = { version = "0.11.2", features = ["macros"] }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.3.0" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }

--- a/iota_interaction/Cargo.toml
+++ b/iota_interaction/Cargo.toml
@@ -22,13 +22,13 @@ jsonpath-rust = { version = "0.5.1", optional = true }
 secret-storage.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-shared-crypto = { git = "https://github.com/iotaledger/iota.git", package = "shared-crypto", tag = "v1.6.1" }
+shared-crypto = { git = "https://github.com/iotaledger/iota.git", package = "shared-crypto", tag = "v1.7.0-rc" }
 strum.workspace = true
 thiserror.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.6.1" }
-move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.6.1" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.7.0-rc" }
+move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.7.0-rc" }
 tokio = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/iota_interaction/src/sdk_types/iota_types/execution_status.rs
+++ b/iota_interaction/src/sdk_types/iota_types/execution_status.rs
@@ -279,6 +279,11 @@ pub enum CommandArgumentError {
         allowed."
     )]
     SharedObjectOperationNotAllowed,
+    #[error(
+        "Invalid argument arity. Expected a single argument but found a result that expanded to \
+        multiple arguments."
+    )]
+    InvalidArgumentArity,
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Hash, Error)]

--- a/product_common/Cargo.toml
+++ b/product_common/Cargo.toml
@@ -17,7 +17,7 @@ async-trait.workspace = true
 bcs = { workspace = true, optional = true }
 cfg-if.workspace = true
 fastcrypto = { workspace = true, optional = true }
-iota-keys = { git = "https://github.com/iotaledger/iota.git", package = "iota-keys", tag = "v1.6.1", optional = true }
+iota-keys = { git = "https://github.com/iotaledger/iota.git", package = "iota-keys", tag = "v1.7.0-rc", optional = true }
 itertools = { version = "0.13.0", optional = true }
 lazy_static = { version = "1.5.0", optional = true }
 phf.workspace = true


### PR DESCRIPTION
# Description of change

- [ ] tokio version update to: -
- [ ] fastcrypto version update to rev = "-"
- [x] changes in iota_interaction/src/sdk_types
- [ ] iota_interaction_ts: new peerDep. version for @iota/iota-sdk: _
- [x] pin all iota.git dependencies to tag = "v1.7.0-rc"

## Links to any relevant issues

None

## How the change has been tested

The changes have been tested using IOTA version "v1.7.0-rc" with the following test PRs:

* Identity: https://github.com/iotaledger/identity/pull/1723
* Notarization: https://github.com/iotaledger/notarization/pull/136