### PR TITLE
Release: Version 0.8.7 (Rust only)

### DIFF
--- a/bindings/wasm/iota_interaction_ts/Cargo.toml
+++ b/bindings/wasm/iota_interaction_ts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iota_interaction_ts"
-version = "0.8.6"
+version = "0.8.7"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
@@ -24,7 +24,7 @@ eyre = "0.6.12"
 fastcrypto.workspace = true
 futures = { version = "0.3" }
 iota-sdk = { version = "1.1.5", default-features = false, features = ["serde", "std"] }
-iota_interaction = { version = "0.8.6", path = "../../../iota_interaction", default-features = false }
+iota_interaction = { version = "0.8.7", path = "../../../iota_interaction", default-features = false }
 js-sys = { version = "0.3.61" }
 json-proof-token = { version = "0.3.5", optional = true }
 sd-jwt-payload = { version = "0.2.1", default-features = false, features = ["sha"], optional = true }

--- a/iota_interaction/Cargo.toml
+++ b/iota_interaction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iota_interaction"
-version = "0.8.6"
+version = "0.8.7"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/iota_interaction_rust/Cargo.toml
+++ b/iota_interaction_rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iota_interaction_rust"
-version = "0.8.6"
+version = "0.8.7"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
@@ -19,7 +19,7 @@ secret-storage.workspace = true
 serde.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iota_interaction = { version = "0.8.6", path = "../iota_interaction" }
+iota_interaction = { version = "0.8.7", path = "../iota_interaction" }
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/product_common/Cargo.toml
+++ b/product_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "product_common"
-version = "0.8.6"
+version = "0.8.7"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
@@ -37,19 +37,19 @@ toml = { workspace = true } # , optional = true --- TODO see comment for `move-h
 url = { version = "2", default-features = false, features = ["serde"], optional = true }
 
 [dev-dependencies]
-iota_interaction = { path = "../iota_interaction", version = "0.8.6" }
-iota_interaction_rust = { path = "../iota_interaction_rust", version = "0.8.6" }
+iota_interaction = { path = "../iota_interaction", version = "0.8.7" }
+iota_interaction_rust = { path = "../iota_interaction_rust", version = "0.8.7" }
 tempfile.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iota_interaction = { path = "../iota_interaction", version = "0.8.6", features = ["keytool"] }
-iota_interaction_rust = { path = "../iota_interaction_rust", version = "0.8.6", optional = true }
+iota_interaction = { path = "../iota_interaction", version = "0.8.7", features = ["keytool"] }
+iota_interaction_rust = { path = "../iota_interaction_rust", version = "0.8.7", optional = true }
 iota-sdk.workspace = true
 tokio.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-iota_interaction = { path = "../iota_interaction", version = "0.8.6", default-features = false }
-iota_interaction_ts = { path = "../bindings/wasm/iota_interaction_ts", version = "0.8.6" }
+iota_interaction = { path = "../iota_interaction", version = "0.8.7", default-features = false }
+iota_interaction_ts = { path = "../bindings/wasm/iota_interaction_ts", version = "0.8.7" }
 js-sys = { version = "0.3", optional = true }
 serde-wasm-bindgen = { version = "0.6", optional = true }
 wasm-bindgen = { version = "0.2.100", optional = true }


### PR DESCRIPTION
# Description of change

* Bump all cargo packages to version 0.8.7
* @iota/iota-interaction-ts npmjs package version stays with 0.9.0