### PR TITLE
Upstream merge to iota v1.19.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ bcs = "0.1.6"
 cfg-if = "1.0.0"
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto" }
 hyper = "1"
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.19.1-rc" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.19.1" }
 iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "d8cdab6ab3f2fd9ba8059ba56e80ba950badc88d", features = ["hash", "serde", "schemars"] }
-move-binary-format = { git = "https://github.com/iotaledger/iota.git", package = "move-binary-format", tag = "v1.19.1-rc" }
-move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.19.1-rc" }
-move-bytecode-utils = { git = "https://github.com/iotaledger/iota.git", package = "move-bytecode-utils", tag = "v1.19.1-rc" }
+move-binary-format = { git = "https://github.com/iotaledger/iota.git", package = "move-binary-format", tag = "v1.19.1" }
+move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.19.1" }
+move-bytecode-utils = { git = "https://github.com/iotaledger/iota.git", package = "move-bytecode-utils", tag = "v1.19.1" }
 phf = { version = "0.11.2", features = ["macros"] }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.3.0" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive", "rc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ bcs = "0.1.6"
 cfg-if = "1.0.0"
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto" }
 hyper = "1"
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.18.1" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.19.1-rc" }
 iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "d8cdab6ab3f2fd9ba8059ba56e80ba950badc88d", features = ["hash", "serde", "schemars"] }
-move-binary-format = { git = "https://github.com/iotaledger/iota.git", package = "move-binary-format", tag = "v1.18.1" }
-move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.18.1" }
-move-bytecode-utils = { git = "https://github.com/iotaledger/iota.git", package = "move-bytecode-utils", tag = "v1.18.1" }
+move-binary-format = { git = "https://github.com/iotaledger/iota.git", package = "move-binary-format", tag = "v1.19.1-rc" }
+move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.19.1-rc" }
+move-bytecode-utils = { git = "https://github.com/iotaledger/iota.git", package = "move-bytecode-utils", tag = "v1.19.1-rc" }
 phf = { version = "0.11.2", features = ["macros"] }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.3.0" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive", "rc"] }

--- a/iota_interaction/Cargo.toml
+++ b/iota_interaction/Cargo.toml
@@ -31,8 +31,8 @@ thiserror.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 hyper.workspace = true
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.18.1" }
-move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.18.1" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.19.1-rc" }
+move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.19.1-rc" }
 tokio = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/iota_interaction/Cargo.toml
+++ b/iota_interaction/Cargo.toml
@@ -31,8 +31,8 @@ thiserror.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 hyper.workspace = true
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.19.1-rc" }
-move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.19.1-rc" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.19.1" }
+move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.19.1" }
 tokio = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/iota_interaction/src/sdk_types/iota_types/auth_context/fields_v1.rs
+++ b/iota_interaction/src/sdk_types/iota_types/auth_context/fields_v1.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 IOTA Stiftung
+// Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::ident_str;
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::{
     IOTA_FRAMEWORK_ADDRESS,
-    base_types::ObjectID,
+    base_types::{ObjectDigest, ObjectID, SequenceNumber},
     transaction::{Argument, CallArg, Command, ObjectArg},
     type_input::TypeName,
 };
@@ -33,15 +33,15 @@ pub const MAKE_MOVE_VEC_DATA_STRUCT_NAME: &IdentStr = ident_str!("MakeMoveVecDat
 pub const UPGRADE_DATA_STRUCT_NAME: &IdentStr = ident_str!("UpgradeData");
 
 // ---------------------------------------------------------------------------
-// AuthContextMoveCall
+// MoveProgrammableMoveCall
 // ---------------------------------------------------------------------------
 
 /// Mirrors [`crate::transaction::ProgrammableMoveCall`] for use in
-/// [`AuthContextCommand`], substituting [`TypeName`] for
+/// [`MoveCommand`], substituting [`TypeName`] for
 /// [`crate::type_input::TypeInput`] so that the type can derive
 /// [`Serialize`]/[`Deserialize`] without a custom implementation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AuthContextMoveCall {
+pub struct MoveProgrammableMoveCall {
     pub package: ObjectID,
     pub module: String,
     pub function: String,
@@ -50,7 +50,7 @@ pub struct AuthContextMoveCall {
 }
 
 // ---------------------------------------------------------------------------
-// AuthContextCommand
+// MoveCommand
 // ---------------------------------------------------------------------------
 
 /// Mirrors [`crate::transaction::Command`], substituting [`TypeName`] for
@@ -58,8 +58,8 @@ pub struct AuthContextMoveCall {
 /// the type matches the BCS layout expected by the Move-side
 /// `ptb_command::Command`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum AuthContextCommand {
-    MoveCall(Box<AuthContextMoveCall>),
+pub enum MoveCommand {
+    MoveCall(Box<MoveProgrammableMoveCall>),
     TransferObjects(Vec<Argument>, Argument),
     SplitCoins(Argument, Vec<Argument>),
     MergeCoins(Argument, Vec<Argument>),
@@ -68,10 +68,10 @@ pub enum AuthContextCommand {
     Upgrade(Vec<Vec<u8>>, Vec<ObjectID>, ObjectID, Argument),
 }
 
-impl From<&Command> for AuthContextCommand {
+impl From<&Command> for MoveCommand {
     fn from(cmd: &Command) -> Self {
         match cmd {
-            Command::MoveCall(m) => AuthContextCommand::MoveCall(Box::new(AuthContextMoveCall {
+            Command::MoveCall(m) => MoveCommand::MoveCall(Box::new(MoveProgrammableMoveCall {
                 package: m.package,
                 module: m.module.clone(),
                 function: m.function.clone(),
@@ -79,23 +79,20 @@ impl From<&Command> for AuthContextCommand {
                 arguments: m.arguments.clone(),
             })),
             Command::TransferObjects(objects, recipient) => {
-                AuthContextCommand::TransferObjects(objects.clone(), *recipient)
+                MoveCommand::TransferObjects(objects.clone(), *recipient)
             }
-            Command::SplitCoins(coin, amounts) => {
-                AuthContextCommand::SplitCoins(*coin, amounts.clone())
-            }
+            Command::SplitCoins(coin, amounts) => MoveCommand::SplitCoins(*coin, amounts.clone()),
             Command::MergeCoins(target_coin, source_coins) => {
-                AuthContextCommand::MergeCoins(*target_coin, source_coins.clone())
+                MoveCommand::MergeCoins(*target_coin, source_coins.clone())
             }
             Command::Publish(modules, dependencies) => {
-                AuthContextCommand::Publish(modules.clone(), dependencies.clone())
+                MoveCommand::Publish(modules.clone(), dependencies.clone())
             }
-            Command::MakeMoveVec(type_arg, elements) => AuthContextCommand::MakeMoveVec(
-                type_arg.as_ref().map(TypeName::from),
-                elements.clone(),
-            ),
+            Command::MakeMoveVec(type_arg, elements) => {
+                MoveCommand::MakeMoveVec(type_arg.as_ref().map(TypeName::from), elements.clone())
+            }
             Command::Upgrade(modules, dependencies, package, upgrade_ticket) => {
-                AuthContextCommand::Upgrade(
+                MoveCommand::Upgrade(
                     modules.clone(),
                     dependencies.clone(),
                     *package,
@@ -106,7 +103,7 @@ impl From<&Command> for AuthContextCommand {
     }
 }
 
-impl AuthContextCommand {
+impl MoveCommand {
     pub fn type_() -> StructTag {
         StructTag {
             address: IOTA_FRAMEWORK_ADDRESS,
@@ -118,27 +115,69 @@ impl AuthContextCommand {
 }
 
 // ---------------------------------------------------------------------------
-// AuthContextCallArg
+// MoveCallArg
 // ---------------------------------------------------------------------------
 
-/// Mirrors [`crate::transaction::CallArg`], matching the BCS layout expected
-/// by the Move-side `ptb_call_arg::CallArg`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum AuthContextCallArg {
-    Pure(Vec<u8>),
-    Object(ObjectArg),
+/// Mirrors [`crate::transaction::ObjectArg`], matching the BCS layout expected
+/// by the Move-side `ptb_call_arg::ObjectArg`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MoveObjectArg {
+    ImmOrOwnedObject((ObjectID, SequenceNumber, ObjectDigest)),
+    SharedObject {
+        id: ObjectID,
+        initial_shared_version: SequenceNumber,
+        mutable: bool,
+    },
+    Receiving((ObjectID, SequenceNumber, ObjectDigest)),
 }
 
-impl From<&CallArg> for AuthContextCallArg {
-    fn from(arg: &CallArg) -> Self {
-        match arg {
-            CallArg::Pure(bytes) => AuthContextCallArg::Pure(bytes.clone()),
-            CallArg::Object(obj_arg) => AuthContextCallArg::Object(*obj_arg),
+impl From<&ObjectArg> for MoveObjectArg {
+    fn from(obj: &ObjectArg) -> Self {
+        match obj {
+            ObjectArg::ImmOrOwnedObject(r) => MoveObjectArg::ImmOrOwnedObject(*r),
+            ObjectArg::SharedObject {
+                id,
+                initial_shared_version,
+                mutable,
+            } => MoveObjectArg::SharedObject {
+                id: *id,
+                initial_shared_version: *initial_shared_version,
+                mutable: *mutable,
+            },
+            ObjectArg::Receiving(r) => MoveObjectArg::Receiving(*r),
         }
     }
 }
 
-impl AuthContextCallArg {
+impl MoveObjectArg {
+    pub fn type_() -> StructTag {
+        StructTag {
+            address: IOTA_FRAMEWORK_ADDRESS,
+            module: CALL_ARG_MODULE_NAME.to_owned(),
+            name: OBJECT_ARG_STRUCT_NAME.to_owned(),
+            type_params: vec![],
+        }
+    }
+}
+
+/// Mirrors [`crate::transaction::CallArg`], matching the BCS layout expected
+/// by the Move-side `ptb_call_arg::CallArg`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MoveCallArg {
+    Pure(Vec<u8>),
+    Object(MoveObjectArg),
+}
+
+impl From<&CallArg> for MoveCallArg {
+    fn from(arg: &CallArg) -> Self {
+        match arg {
+            CallArg::Pure(bytes) => MoveCallArg::Pure(bytes.clone()),
+            CallArg::Object(obj_arg) => MoveCallArg::Object(MoveObjectArg::from(obj_arg)),
+        }
+    }
+}
+
+impl MoveCallArg {
     pub fn type_() -> StructTag {
         StructTag {
             address: IOTA_FRAMEWORK_ADDRESS,
@@ -151,7 +190,7 @@ impl AuthContextCallArg {
 
 #[cfg(test)]
 mod tests {
-    use crate::move_core_types::account_address::AccountAddress;
+    use move_core_types::account_address::AccountAddress;
 
     use super::*;
     use crate::{
@@ -183,23 +222,23 @@ mod tests {
         bcs::from_bytes(&bytes).unwrap()
     }
 
-    // ── AuthContextCallArg ───────────────────────────────────────────────────
+    // ── MoveCallArg ───────────────────────────────────────────────────
 
     #[test]
     fn call_arg_pure_round_trip() {
-        let arg = AuthContextCallArg::Pure(vec![1, 2, 3]);
+        let arg = MoveCallArg::Pure(vec![1, 2, 3]);
         assert_eq!(round_trip(&arg), arg);
     }
 
     #[test]
     fn call_arg_imm_or_owned_round_trip() {
-        let arg = AuthContextCallArg::Object(ObjectArg::ImmOrOwnedObject(obj_ref()));
+        let arg = MoveCallArg::Object(MoveObjectArg::ImmOrOwnedObject(obj_ref()));
         assert_eq!(round_trip(&arg), arg);
     }
 
     #[test]
     fn call_arg_shared_object_round_trip() {
-        let arg = AuthContextCallArg::Object(ObjectArg::SharedObject {
+        let arg = MoveCallArg::Object(MoveObjectArg::SharedObject {
             id: obj_id(),
             initial_shared_version: SequenceNumber::from(5),
             mutable: true,
@@ -209,37 +248,76 @@ mod tests {
 
     #[test]
     fn call_arg_receiving_round_trip() {
-        let arg = AuthContextCallArg::Object(ObjectArg::Receiving(obj_ref()));
+        let arg = MoveCallArg::Object(MoveObjectArg::Receiving(obj_ref()));
         assert_eq!(round_trip(&arg), arg);
     }
 
-    // ── From<&CallArg> for AuthContextCallArg ────────────────────────────────
+    // ── From<&CallArg> for MoveCallArg ────────────────────────────────
 
     #[test]
     fn call_arg_from_pure() {
         let data = vec![10, 20, 30];
-        let converted = AuthContextCallArg::from(&CallArg::Pure(data.clone()));
-        assert_eq!(converted, AuthContextCallArg::Pure(data));
+        let converted = MoveCallArg::from(&CallArg::Pure(data.clone()));
+        assert_eq!(converted, MoveCallArg::Pure(data));
     }
 
     #[test]
     fn call_arg_from_object() {
         let obj_arg = ObjectArg::ImmOrOwnedObject(obj_ref());
-        let converted = AuthContextCallArg::from(&CallArg::Object(obj_arg));
-        assert_eq!(converted, AuthContextCallArg::Object(obj_arg));
+        let converted = MoveCallArg::from(&CallArg::Object(obj_arg));
+        assert_eq!(
+            converted,
+            MoveCallArg::Object(MoveObjectArg::ImmOrOwnedObject(obj_ref()))
+        );
     }
 
     #[test]
     fn call_arg_from_call_arg() {
         let call_arg = CallArg::Pure(vec![99]);
-        let converted = AuthContextCallArg::from(&call_arg);
-        assert!(matches!(converted, AuthContextCallArg::Pure(_)));
+        let converted = MoveCallArg::from(&call_arg);
+        assert!(matches!(converted, MoveCallArg::Pure(_)));
     }
 
-    // ── AuthContextCommand round-trips ────────────────────────────────────────
+    // ── BCS compatibility: MoveObjectArg ↔ ObjectArg ─────────────────
 
-    fn sample_move_call() -> AuthContextCommand {
-        AuthContextCommand::MoveCall(Box::new(AuthContextMoveCall {
+    #[test]
+    fn object_arg_bcs_compatible_imm_or_owned() {
+        let tx_arg = ObjectArg::ImmOrOwnedObject(obj_ref());
+        let ctx_arg = MoveObjectArg::from(&tx_arg);
+        assert_eq!(
+            bcs::to_bytes(&tx_arg).unwrap(),
+            bcs::to_bytes(&ctx_arg).unwrap()
+        );
+    }
+
+    #[test]
+    fn object_arg_bcs_compatible_shared() {
+        let tx_arg = ObjectArg::SharedObject {
+            id: obj_id(),
+            initial_shared_version: SequenceNumber::from(5),
+            mutable: true,
+        };
+        let ctx_arg = MoveObjectArg::from(&tx_arg);
+        assert_eq!(
+            bcs::to_bytes(&tx_arg).unwrap(),
+            bcs::to_bytes(&ctx_arg).unwrap()
+        );
+    }
+
+    #[test]
+    fn object_arg_bcs_compatible_receiving() {
+        let tx_arg = ObjectArg::Receiving(obj_ref());
+        let ctx_arg = MoveObjectArg::from(&tx_arg);
+        assert_eq!(
+            bcs::to_bytes(&tx_arg).unwrap(),
+            bcs::to_bytes(&ctx_arg).unwrap()
+        );
+    }
+
+    // ── MoveCommand round-trips ────────────────────────────────────────
+
+    fn sample_move_call() -> MoveCommand {
+        MoveCommand::MoveCall(Box::new(MoveProgrammableMoveCall {
             package: obj_id(),
             module: "my_module".to_string(),
             function: "my_func".to_string(),
@@ -257,7 +335,7 @@ mod tests {
 
     #[test]
     fn command_transfer_objects_round_trip() {
-        let cmd = AuthContextCommand::TransferObjects(
+        let cmd = MoveCommand::TransferObjects(
             vec![Argument::Input(0), Argument::Result(1)],
             Argument::Input(2),
         );
@@ -266,13 +344,13 @@ mod tests {
 
     #[test]
     fn command_split_coins_round_trip() {
-        let cmd = AuthContextCommand::SplitCoins(Argument::GasCoin, vec![Argument::Input(0)]);
+        let cmd = MoveCommand::SplitCoins(Argument::GasCoin, vec![Argument::Input(0)]);
         assert_eq!(round_trip(&cmd), cmd);
     }
 
     #[test]
     fn command_merge_coins_round_trip() {
-        let cmd = AuthContextCommand::MergeCoins(
+        let cmd = MoveCommand::MergeCoins(
             Argument::GasCoin,
             vec![Argument::Input(0), Argument::Input(1)],
         );
@@ -281,13 +359,13 @@ mod tests {
 
     #[test]
     fn command_publish_round_trip() {
-        let cmd = AuthContextCommand::Publish(vec![vec![1, 2, 3]], vec![obj_id()]);
+        let cmd = MoveCommand::Publish(vec![vec![1, 2, 3]], vec![obj_id()]);
         assert_eq!(round_trip(&cmd), cmd);
     }
 
     #[test]
     fn command_make_move_vec_with_type_round_trip() {
-        let cmd = AuthContextCommand::MakeMoveVec(
+        let cmd = MoveCommand::MakeMoveVec(
             Some(TypeName {
                 name: "0x2::coin::Coin<u64>".to_string(),
             }),
@@ -298,13 +376,13 @@ mod tests {
 
     #[test]
     fn command_make_move_vec_no_type_round_trip() {
-        let cmd = AuthContextCommand::MakeMoveVec(None, vec![Argument::Result(0)]);
+        let cmd = MoveCommand::MakeMoveVec(None, vec![Argument::Result(0)]);
         assert_eq!(round_trip(&cmd), cmd);
     }
 
     #[test]
     fn command_upgrade_round_trip() {
-        let cmd = AuthContextCommand::Upgrade(
+        let cmd = MoveCommand::Upgrade(
             vec![vec![0xde, 0xad]],
             vec![obj_id()],
             obj_id(),
@@ -313,7 +391,7 @@ mod tests {
         assert_eq!(round_trip(&cmd), cmd);
     }
 
-    // ── From<&Command> for AuthContextCommand ────────────────────────────────
+    // ── From<&Command> for MoveCommand ────────────────────────────────
 
     /// Primitive TypeInput variants (Bool, U8, …) must be converted to their
     /// canonical string representation as TypeName.
@@ -337,7 +415,7 @@ mod tests {
                 type_arguments: vec![type_input],
                 arguments: vec![],
             }));
-            let AuthContextCommand::MoveCall(call) = AuthContextCommand::from(&cmd) else {
+            let MoveCommand::MoveCall(call) = MoveCommand::from(&cmd) else {
                 panic!("expected MoveCall");
             };
             assert_eq!(
@@ -368,7 +446,7 @@ mod tests {
             type_arguments: vec![type_input],
             arguments: vec![],
         }));
-        let AuthContextCommand::MoveCall(call) = AuthContextCommand::from(&cmd) else {
+        let MoveCommand::MoveCall(call) = MoveCommand::from(&cmd) else {
             panic!("expected MoveCall");
         };
         assert_eq!(call.type_arguments, vec![expected]);
@@ -379,7 +457,7 @@ mod tests {
         let type_input = TypeInput::Bool;
         let expected = TypeName::from(&type_input);
         let cmd = Command::MakeMoveVec(Some(type_input), vec![Argument::Input(0)]);
-        let AuthContextCommand::MakeMoveVec(name, _) = AuthContextCommand::from(&cmd) else {
+        let MoveCommand::MakeMoveVec(name, _) = MoveCommand::from(&cmd) else {
             panic!("expected MakeMoveVec");
         };
         assert_eq!(name, Some(expected));
@@ -388,7 +466,7 @@ mod tests {
     #[test]
     fn command_from_make_move_vec_none_type() {
         let cmd = Command::MakeMoveVec(None, vec![]);
-        let AuthContextCommand::MakeMoveVec(name, elements) = AuthContextCommand::from(&cmd) else {
+        let MoveCommand::MakeMoveVec(name, elements) = MoveCommand::from(&cmd) else {
             panic!("expected MakeMoveVec");
         };
         assert!(name.is_none());
@@ -404,7 +482,7 @@ mod tests {
             type_arguments: vec![TypeInput::U8],
             arguments: vec![],
         }));
-        let converted = AuthContextCommand::from(&cmd);
-        assert!(matches!(converted, AuthContextCommand::MoveCall(_)));
+        let converted = MoveCommand::from(&cmd);
+        assert!(matches!(converted, MoveCommand::MoveCall(_)));
     }
 }

--- a/iota_interaction/src/sdk_types/iota_types/auth_context/mod.rs
+++ b/iota_interaction/src/sdk_types/iota_types/auth_context/mod.rs
@@ -1,5 +1,6 @@
-// Copyright (c) 2025 IOTA Stiftung
+// Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
+
 mod fields_v1;
 
 pub use fields_v1::*;
@@ -49,9 +50,9 @@ pub struct AuthContext {
     /// The digest of the MoveAuthenticator
     auth_digest: MoveAuthenticatorDigest,
     /// The authentication input objects or primitive values
-    tx_inputs: Vec<AuthContextCallArg>,
+    tx_inputs: Vec<MoveCallArg>,
     /// The authentication commands to be executed sequentially.
-    tx_commands: Vec<AuthContextCommand>,
+    tx_commands: Vec<MoveCommand>,
 }
 
 impl AuthContext {
@@ -61,8 +62,8 @@ impl AuthContext {
     ) -> Self {
         Self {
             auth_digest,
-            tx_inputs: ptb.inputs.iter().map(AuthContextCallArg::from).collect(),
-            tx_commands: ptb.commands.iter().map(AuthContextCommand::from).collect(),
+            tx_inputs: ptb.inputs.iter().map(MoveCallArg::from).collect(),
+            tx_commands: ptb.commands.iter().map(MoveCommand::from).collect(),
         }
     }
 
@@ -78,11 +79,11 @@ impl AuthContext {
         &self.auth_digest
     }
 
-    pub fn tx_inputs(&self) -> &Vec<AuthContextCallArg> {
+    pub fn tx_inputs(&self) -> &Vec<MoveCallArg> {
         &self.tx_inputs
     }
 
-    pub fn tx_commands(&self) -> &Vec<AuthContextCommand> {
+    pub fn tx_commands(&self) -> &Vec<MoveCommand> {
         &self.tx_commands
     }
 
@@ -127,13 +128,14 @@ impl AuthContext {
         }
     }
 
-    // Move test only API
-    //
+    /// Replaces the contents of the `AuthContext` with new values. This is
+    /// intended for use within a Move test function, as the `AuthContext`
+    /// should be immutable during normal use.
     pub fn replace(
         &mut self,
         auth_digest: MoveAuthenticatorDigest,
-        tx_inputs: Vec<AuthContextCallArg>,
-        tx_commands: Vec<AuthContextCommand>,
+        tx_inputs: Vec<MoveCallArg>,
+        tx_commands: Vec<MoveCommand>,
     ) {
         self.auth_digest = auth_digest;
         self.tx_inputs = tx_inputs;
@@ -147,8 +149,8 @@ impl AuthContext {
 #[derive(Default, Serialize)]
 pub struct MoveAuthContext {
     auth_digest: MoveAuthenticatorDigest,
-    tx_inputs: Vec<AuthContextCallArg>,
-    tx_commands: Vec<AuthContextCommand>,
+    tx_inputs: Vec<MoveCallArg>,
+    tx_commands: Vec<MoveCommand>,
 }
 
 #[derive(PartialEq, Eq, Clone, Copy)]
@@ -200,10 +202,10 @@ mod tests {
         assert_eq!(ctx.tx_inputs().len(), 1);
         assert_eq!(ctx.tx_commands().len(), 1);
 
-        assert!(matches!(ctx.tx_inputs()[0], AuthContextCallArg::Pure(_)));
+        assert!(matches!(ctx.tx_inputs()[0], MoveCallArg::Pure(_)));
 
         // Commands must have TypeName substituted for TypeInput.
-        let AuthContextCommand::MoveCall(call) = &ctx.tx_commands()[0] else {
+        let MoveCommand::MoveCall(call) = &ctx.tx_commands()[0] else {
             panic!("expected MoveCall");
         };
         assert_eq!(
@@ -227,7 +229,7 @@ mod tests {
 
         ctx.replace(
             MoveAuthenticatorDigest::default(),
-            vec![AuthContextCallArg::Pure(vec![1])],
+            vec![MoveCallArg::Pure(vec![1])],
             vec![],
         );
         let non_empty_bytes = ctx.to_bcs_bytes();

--- a/iota_interaction/src/sdk_types/iota_types/crypto.rs
+++ b/iota_interaction/src/sdk_types/iota_types/crypto.rs
@@ -501,6 +501,7 @@ impl Signer<Signature> for Secp256k1KeyPair {
         Secp256k1IotaSignature::new(self, msg).into()
     }
 }
+
 // Secp256r1 Iota Signature port
 //
 #[serde_as]
@@ -540,6 +541,7 @@ impl Signer<Signature> for Secp256r1KeyPair {
         Secp256r1IotaSignature::new(self, msg).into()
     }
 }
+
 // This struct exists due to the limitations of the `enum_dispatch` library.
 //
 pub trait IotaSignatureInner: Sized + ToFromBytes + PartialEq + Eq + Hash {

--- a/product_common/Cargo.toml
+++ b/product_common/Cargo.toml
@@ -23,7 +23,7 @@ async-trait.workspace = true
 bcs = { workspace = true, optional = true }
 cfg-if.workspace = true
 fastcrypto = { workspace = true, optional = true }
-iota-keys = { package = "iota-keys", git = "https://github.com/iotaledger/iota.git", tag = "v1.18.1", optional = true }
+iota-keys = { package = "iota-keys", git = "https://github.com/iotaledger/iota.git", tag = "v1.19.1-rc", optional = true }
 iota-sdk-types = { workspace = true, features = ["serde"] }
 itertools = { version = "0.13.0", optional = true }
 lazy_static = { version = "1.5.0", optional = true }

--- a/product_common/Cargo.toml
+++ b/product_common/Cargo.toml
@@ -23,7 +23,7 @@ async-trait.workspace = true
 bcs = { workspace = true, optional = true }
 cfg-if.workspace = true
 fastcrypto = { workspace = true, optional = true }
-iota-keys = { package = "iota-keys", git = "https://github.com/iotaledger/iota.git", tag = "v1.19.1-rc", optional = true }
+iota-keys = { package = "iota-keys", git = "https://github.com/iotaledger/iota.git", tag = "v1.19.1", optional = true }
 iota-sdk-types = { workspace = true, features = ["serde"] }
 itertools = { version = "0.13.0", optional = true }
 lazy_static = { version = "1.5.0", optional = true }


### PR DESCRIPTION
# Description of change

Following dependencies have been changed:
- [ ] tokio version update to: -
- [ ] fastcrypto version update to rev = -
- [ ] iota-sdk-types (`https://github.com/iotaledger/iota-rust-sdk.git`) update to rev = -
- [x] changes in iota_interaction/src/sdk_types
- [ ] iota_interaction_ts: new peerDep. version for @iota/iota-sdk: _
- [x] pin all iota.git dependencies to `tag = "v1.19.1-rc"` and later on (after mainnet release) to "v1.19.1"

Changes in iota_interaction/sdk_types:
* Updated `auth_context` implementation to latest changes

## Links to any relevant issues
https://github.com/iotaledger/product-core/issues/67

## How the change has been tested

The changes have been tested using IOTA version "v1.19-rc" with the following test PRs:

* Identity: https://github.com/iotaledger/identity/pull/1802
* Notarization: https://github.com/iotaledger/notarization/pull/230