### PR TITLE
Upstream merge to iota v1.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ bcs = "0.1.6"
 cfg-if = "1.0.0"
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto" }
 hyper = "1"
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.20.0-rc" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.20.1" }
 iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "e19c78a1bee17e0bf85fcd5b16a2f080cef26274", features = ["hash", "serde", "schemars"] }
-move-binary-format = { git = "https://github.com/iotaledger/iota.git", package = "move-binary-format", tag = "v1.20.0-rc" }
-move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.20.0-rc" }
-move-bytecode-utils = { git = "https://github.com/iotaledger/iota.git", package = "move-bytecode-utils", tag = "v1.20.0-rc" }
+move-binary-format = { git = "https://github.com/iotaledger/iota.git", package = "move-binary-format", tag = "v1.20.1" }
+move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.20.1" }
+move-bytecode-utils = { git = "https://github.com/iotaledger/iota.git", package = "move-bytecode-utils", tag = "v1.20.1" }
 phf = { version = "0.11.2", features = ["macros"] }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.3.0" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive", "rc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ bcs = "0.1.6"
 cfg-if = "1.0.0"
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto" }
 hyper = "1"
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.19.1" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "d8cdab6ab3f2fd9ba8059ba56e80ba950badc88d", features = ["hash", "serde", "schemars"] }
-move-binary-format = { git = "https://github.com/iotaledger/iota.git", package = "move-binary-format", tag = "v1.19.1" }
-move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.19.1" }
-move-bytecode-utils = { git = "https://github.com/iotaledger/iota.git", package = "move-bytecode-utils", tag = "v1.19.1" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.20.0-rc" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "e19c78a1bee17e0bf85fcd5b16a2f080cef26274", features = ["hash", "serde", "schemars"] }
+move-binary-format = { git = "https://github.com/iotaledger/iota.git", package = "move-binary-format", tag = "v1.20.0-rc" }
+move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.20.0-rc" }
+move-bytecode-utils = { git = "https://github.com/iotaledger/iota.git", package = "move-bytecode-utils", tag = "v1.20.0-rc" }
 phf = { version = "0.11.2", features = ["macros"] }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.3.0" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive", "rc"] }

--- a/iota_interaction/Cargo.toml
+++ b/iota_interaction/Cargo.toml
@@ -31,8 +31,8 @@ thiserror.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 hyper.workspace = true
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.19.1" }
-move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.19.1" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.20.0-rc" }
+move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.20.0-rc" }
 tokio = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/iota_interaction/Cargo.toml
+++ b/iota_interaction/Cargo.toml
@@ -31,8 +31,8 @@ thiserror.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 hyper.workspace = true
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.20.0-rc" }
-move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.20.0-rc" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.20.1" }
+move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.20.1" }
 tokio = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/iota_interaction/src/sdk_types/iota_json_rpc_types/iota_move.rs
+++ b/iota_interaction/src/sdk_types/iota_json_rpc_types/iota_move.rs
@@ -105,7 +105,7 @@ impl From<MoveValue> for IotaMoveValue {
                 tag: _,
                 fields,
             }) => IotaMoveValue::Variant(IotaMoveVariant {
-                type_: type_.clone(),
+                type_,
                 variant: variant_name.to_string(),
                 fields: fields
                     .into_iter()

--- a/iota_interaction/src/sdk_types/iota_types/crypto.rs
+++ b/iota_interaction/src/sdk_types/iota_types/crypto.rs
@@ -5,9 +5,12 @@ use std::hash::Hash;
 use std::str::FromStr;
 
 use derive_more::{AsMut, AsRef, From};
-use enum_dispatch::enum_dispatch;
+pub use enum_dispatch::enum_dispatch;
 use eyre::{eyre, Report};
-use fastcrypto::bls12381::min_sig::{
+pub use fastcrypto::traits::{
+    Authenticator, EncodeDecodeBase64, KeyPair as KeypairTraits, Signer, ToFromBytes, VerifyingKey,
+};
+pub use fastcrypto::bls12381::min_sig::{
   BLS12381AggregateSignature, BLS12381AggregateSignatureAsBytes, BLS12381KeyPair, BLS12381PrivateKey,
   BLS12381PublicKey, BLS12381Signature,
 };
@@ -19,9 +22,6 @@ use fastcrypto::error::{FastCryptoError, FastCryptoResult};
 use fastcrypto::hash::{Blake2b256, HashFunction};
 use fastcrypto::secp256k1::{Secp256k1KeyPair, Secp256k1PublicKey, Secp256k1PublicKeyAsBytes, Secp256k1Signature};
 use fastcrypto::secp256r1::{Secp256r1KeyPair, Secp256r1PublicKey, Secp256r1PublicKeyAsBytes, Secp256r1Signature};
-use fastcrypto::traits::{
-  Authenticator, EncodeDecodeBase64, KeyPair as KeypairTraits, Signer, ToFromBytes, VerifyingKey,
-};
 use fastcrypto_zkp::zk_login_utils::Bn254FrElement;
 use iota_sdk_types::crypto::IntentMessage;
 use schemars::JsonSchema;

--- a/iota_interaction/src/sdk_types/iota_types/transaction.rs
+++ b/iota_interaction/src/sdk_types/iota_types/transaction.rs
@@ -58,11 +58,6 @@ impl CallArg {
         initial_shared_version: IOTA_CLOCK_OBJECT_SHARED_VERSION,
         mutable: true,
     });
-    pub const AUTHENTICATOR_MUT: Self = Self::Object(ObjectArg::SharedObject {
-        id: IOTA_AUTHENTICATOR_STATE_OBJECT_ID,
-        initial_shared_version: IOTA_AUTHENTICATOR_STATE_OBJECT_SHARED_VERSION,
-        mutable: true,
-    });
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize)]

--- a/product_common/Cargo.toml
+++ b/product_common/Cargo.toml
@@ -23,7 +23,7 @@ async-trait.workspace = true
 bcs = { workspace = true, optional = true }
 cfg-if.workspace = true
 fastcrypto = { workspace = true, optional = true }
-iota-keys = { package = "iota-keys", git = "https://github.com/iotaledger/iota.git", tag = "v1.19.1", optional = true }
+iota-keys = { package = "iota-keys", git = "https://github.com/iotaledger/iota.git", tag = "v1.20.0-rc", optional = true }
 iota-sdk-types = { workspace = true, features = ["serde"] }
 itertools = { version = "0.13.0", optional = true }
 lazy_static = { version = "1.5.0", optional = true }

--- a/product_common/Cargo.toml
+++ b/product_common/Cargo.toml
@@ -23,7 +23,7 @@ async-trait.workspace = true
 bcs = { workspace = true, optional = true }
 cfg-if.workspace = true
 fastcrypto = { workspace = true, optional = true }
-iota-keys = { package = "iota-keys", git = "https://github.com/iotaledger/iota.git", tag = "v1.20.0-rc", optional = true }
+iota-keys = { package = "iota-keys", git = "https://github.com/iotaledger/iota.git", tag = "v1.20.1", optional = true }
 iota-sdk-types = { workspace = true, features = ["serde"] }
 itertools = { version = "0.13.0", optional = true }
 lazy_static = { version = "1.5.0", optional = true }


### PR DESCRIPTION
# Description of change

Following dependencies have been changed:
- [ ] tokio version update to: -
- [ ] fastcrypto version update to rev = "-"
- [x] iota-sdk-types (`https://github.com/iotaledger/iota-rust-sdk.git`) update to rev = e19c78a1bee17e0bf85fcd5b16a2f080cef26274
- [x] changes in iota_interaction/src/sdk_types
- [ ] iota_interaction_ts: new peerDep. version for @iota/iota-sdk: _
- [x] pin all iota.git dependencies to `tag = "v1.20.0-rc"` and later on (after mainnet release) to "v1.20.1"

Additional Changes:
* Added missing pub use statements for fastcrypto::traits and enum_dispatch (36505a2)

Comments:
* There are only minor changes in the `product-core` `iota_interaction/sdk_types`.
* A new release for the `@iota/iota-interaction-ts` npmjs package is not needed.


## Links to any relevant issues

https://github.com/iotaledger/product-core/issues/67

## How the change has been tested

The changes have been tested using IOTA version "v1.20-rc" with the following test PRs:

* Identity: https://github.com/iotaledger/identity/pull/1808
* Notarization: https://github.com/iotaledger/notarization/pull/243