### PR TITLE
Release: Version 0.8.15 (Rust only)

### DIFF
--- a/bindings/wasm/iota_interaction_ts/Cargo.toml
+++ b/bindings/wasm/iota_interaction_ts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iota_interaction_ts"
-version = "0.8.14"
+version = "0.8.15"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
@@ -25,7 +25,7 @@ fastcrypto.workspace = true
 futures = { version = "0.3" }
 hyper = "1"
 iota-sdk = { version = "1.1.5", default-features = false, features = ["serde", "std"] }
-iota_interaction = { version = "0.8.14", path = "../../../iota_interaction", default-features = false }
+iota_interaction = { version = "0.8.15", path = "../../../iota_interaction", default-features = false }
 js-sys = { version = "=0.3.85" }
 json-proof-token = { version = "0.3.5", optional = true }
 sd-jwt-payload = { version = "0.2.1", default-features = false, features = ["sha"], optional = true }

--- a/iota_interaction/Cargo.toml
+++ b/iota_interaction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iota_interaction"
-version = "0.8.14"
+version = "0.8.15"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/iota_interaction_rust/Cargo.toml
+++ b/iota_interaction_rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iota_interaction_rust"
-version = "0.8.14"
+version = "0.8.15"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
@@ -19,7 +19,7 @@ secret-storage.workspace = true
 serde.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iota_interaction = { version = "0.8.14", path = "../iota_interaction" }
+iota_interaction = { version = "0.8.15", path = "../iota_interaction" }
 
 [package.metadata.docs.rs]
 # To build locally:

--- a/product_common/Cargo.toml
+++ b/product_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "product_common"
-version = "0.8.14"
+version = "0.8.15"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
@@ -38,20 +38,20 @@ toml = { workspace = true } # , optional = true --- TODO see comment for `move-h
 url = { version = "2", default-features = false, features = ["serde"], optional = true }
 
 [dev-dependencies]
-iota_interaction = { path = "../iota_interaction", version = "0.8.14" }
-iota_interaction_rust = { path = "../iota_interaction_rust", version = "0.8.14" }
+iota_interaction = { path = "../iota_interaction", version = "0.8.15" }
+iota_interaction_rust = { path = "../iota_interaction_rust", version = "0.8.15" }
 tempfile.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 hyper.workspace = true
-iota_interaction = { path = "../iota_interaction", version = "0.8.14", features = ["keytool"] }
-iota_interaction_rust = { path = "../iota_interaction_rust", version = "0.8.14", optional = true }
+iota_interaction = { path = "../iota_interaction", version = "0.8.15", features = ["keytool"] }
+iota_interaction_rust = { path = "../iota_interaction_rust", version = "0.8.15", optional = true }
 iota-sdk.workspace = true
 tokio.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-iota_interaction = { path = "../iota_interaction", version = "0.8.14", default-features = false }
-iota_interaction_ts = { path = "../bindings/wasm/iota_interaction_ts", version = "0.8.14" }
+iota_interaction = { path = "../iota_interaction", version = "0.8.15", default-features = false }
+iota_interaction_ts = { path = "../bindings/wasm/iota_interaction_ts", version = "0.8.15" }
 js-sys = { version = "0.3", optional = true }
 serde-wasm-bindgen = { version = "0.6", optional = true }
 wasm-bindgen = { version = "0.2.100", optional = true }


### PR DESCRIPTION
# Description of change

* Bump cargo versions to "0.8.15"
* @iota/iota-interaction-ts npmjs package version stays with 0.12.0
