### PR TITLE
Upstream merge to iota v1.22.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ bcs = "0.1.6"
 cfg-if = "1.0.0"
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto" }
 hyper = "1"
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", rev = "96196f0da231883ec69cda04892c600ef6afa982" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "e19c78a1bee17e0bf85fcd5b16a2f080cef26274", features = ["hash", "serde", "schemars"] }
-move-binary-format = { git = "https://github.com/iotaledger/iota.git", package = "move-binary-format", rev = "96196f0da231883ec69cda04892c600ef6afa982" }
-move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", rev = "96196f0da231883ec69cda04892c600ef6afa982" }
-move-bytecode-utils = { git = "https://github.com/iotaledger/iota.git", package = "move-bytecode-utils", rev = "96196f0da231883ec69cda04892c600ef6afa982" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.22.1" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "7c1434aabb2e7b11681722edaf1a51ac52941b84", features = ["hash", "serde", "schemars"] }
+move-binary-format = { git = "https://github.com/iotaledger/iota.git", package = "move-binary-format", tag = "v1.22.1" }
+move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.22.1" }
+move-bytecode-utils = { git = "https://github.com/iotaledger/iota.git", package = "move-bytecode-utils", tag = "v1.22.1" }
 phf = { version = "0.11.2", features = ["macros"] }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.3.0" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive", "rc"] }

--- a/iota_interaction/Cargo.toml
+++ b/iota_interaction/Cargo.toml
@@ -31,8 +31,8 @@ thiserror.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 hyper.workspace = true
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", rev = "96196f0da231883ec69cda04892c600ef6afa982" }
-move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", rev = "96196f0da231883ec69cda04892c600ef6afa982" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.22.1" }
+move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.22.1" }
 tokio = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/iota_interaction/src/sdk_types/iota_types/crypto.rs
+++ b/iota_interaction/src/sdk_types/iota_types/crypto.rs
@@ -200,34 +200,19 @@ pub enum PublicKey {
     Ed25519(Ed25519PublicKeyAsBytes),
     Secp256k1(Secp256k1PublicKeyAsBytes),
     Secp256r1(Secp256r1PublicKeyAsBytes),
-    ZkLogin(ZkLoginPublicIdentifier),
+    #[deprecated(note = "zkLogin is deprecated and was never enabled on IOTA")]
+    ZkLoginDeprecated,
     Passkey(Secp256r1PublicKeyAsBytes),
 }
 
-/// A wrapper struct to retrofit in [enum PublicKey] for zkLogin.
-/// Useful to construct [struct MultiSigPublicKey].
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ZkLoginPublicIdentifier(pub Vec<u8>); // #[schemars(with = "Base64")]
-
-impl ZkLoginPublicIdentifier {
-    /// Consists of iss_bytes_len || iss_bytes || padded_32_byte_address_seed.
-    pub fn new(iss: &str, address_seed: &Bn254FrElement) -> IotaResult<Self> {
-        let mut bytes = Vec::new();
-        let iss_bytes = iss.as_bytes();
-        bytes.extend([iss_bytes.len() as u8]);
-        bytes.extend(iss_bytes);
-        bytes.extend(address_seed.padded());
-
-        Ok(Self(bytes))
-    }
-}
 impl AsRef<[u8]> for PublicKey {
     fn as_ref(&self) -> &[u8] {
         match self {
             PublicKey::Ed25519(pk) => &pk.0,
             PublicKey::Secp256k1(pk) => &pk.0,
             PublicKey::Secp256r1(pk) => &pk.0,
-            PublicKey::ZkLogin(z) => &z.0,
+            #[allow(deprecated)]
+            PublicKey::ZkLoginDeprecated => &[],
             PublicKey::Passkey(pk) => &pk.0,
         }
     }
@@ -306,7 +291,8 @@ impl PublicKey {
             PublicKey::Ed25519(_) => SignatureScheme::ED25519,     // Equals Ed25519IotaSignature::SCHEME
             PublicKey::Secp256k1(_) => SignatureScheme::Secp256k1, // Equals Secp256k1IotaSignature::SCHEME
             PublicKey::Secp256r1(_) => SignatureScheme::Secp256r1, // Equals Secp256r1IotaSignature::SCHEME
-            PublicKey::ZkLogin(_) => SignatureScheme::ZkLoginAuthenticator,
+            #[allow(deprecated)]
+            PublicKey::ZkLoginDeprecated => SignatureScheme::ZkLoginAuthenticatorDeprecated,
             PublicKey::Passkey(_) => SignatureScheme::PasskeyAuthenticator,
         }
     }
@@ -621,7 +607,7 @@ impl<S: IotaSignatureInner + Sized> IotaSignature for S {
         &self,
         value: &IntentMessage<T>,
         author: IotaAddress,
-        scheme: SignatureScheme,
+        _scheme: SignatureScheme,
     ) -> Result<(), IotaError>
     where
         T: Serialize,
@@ -631,17 +617,11 @@ impl<S: IotaSignatureInner + Sized> IotaSignature for S {
         let digest = hasher.finalize().digest;
 
         let (sig, pk) = &self.get_verification_inputs()?;
-        match scheme {
-            SignatureScheme::ZkLoginAuthenticator => {} // Pass this check because zk login does
-            // not derive address from pubkey.
-            _ => {
-                let address = IotaAddress::from(pk);
-                if author != address {
-                    return Err(IotaError::IncorrectSigner {
-                        error: format!("Incorrect signer, expected {author:?}, got {address:?}"),
-                    });
-                }
-            }
+        let address = IotaAddress::from(pk);
+        if author != address {
+            return Err(IotaError::IncorrectSigner {
+                error: format!("Incorrect signer, expected {author:?}, got {address:?}"),
+            });
         }
 
         pk.verify(&digest, sig)
@@ -659,7 +639,8 @@ pub enum SignatureScheme {
     Secp256r1,
     BLS12381, // This is currently not supported for user Iota Address.
     MultiSig,
-    ZkLoginAuthenticator,
+    #[deprecated(note = "zkLogin is deprecated and was never enabled on IOTA")]
+    ZkLoginAuthenticatorDeprecated,
     PasskeyAuthenticator,
     MoveAuthenticator,
 }
@@ -673,7 +654,8 @@ impl SignatureScheme {
             SignatureScheme::MultiSig => 0x03,
             SignatureScheme::BLS12381 => 0x04, // This is currently not supported for user Iota
             // Address.
-            SignatureScheme::ZkLoginAuthenticator => 0x05,
+            #[allow(deprecated)]
+            SignatureScheme::ZkLoginAuthenticatorDeprecated => 0x05,
             SignatureScheme::PasskeyAuthenticator => 0x06,
             SignatureScheme::MoveAuthenticator => 0x07,
         }
@@ -702,7 +684,8 @@ impl SignatureScheme {
             0x02 => Ok(SignatureScheme::Secp256r1),
             0x03 => Ok(SignatureScheme::MultiSig),
             0x04 => Ok(SignatureScheme::BLS12381),
-            0x05 => Ok(SignatureScheme::ZkLoginAuthenticator),
+            #[allow(deprecated)]
+            0x05 => Ok(SignatureScheme::ZkLoginAuthenticatorDeprecated),
             0x06 => Ok(SignatureScheme::PasskeyAuthenticator),
             0x07 => Ok(SignatureScheme::MoveAuthenticator),
             _ => Err(IotaError::KeyConversion("Invalid key scheme".to_string())),

--- a/iota_interaction/src/sdk_types/iota_types/digests.rs
+++ b/iota_interaction/src/sdk_types/iota_types/digests.rs
@@ -494,18 +494,6 @@ impl fmt::Debug for ObjectDigest {
     }
 }
 
-
-/// A digest of a ZkLoginInputs, which commits to the signatures as well as the
-/// tx.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ZKLoginInputsDigest(Digest);
-
-impl ZKLoginInputsDigest {
-    pub const fn new(digest: [u8; 32]) -> Self {
-        Self(Digest::new(digest))
-    }
-}
-
 /// MoveAuthenticatorDigest is the hash (digest) of the `GenericSignature`
 /// payload when the transaction uses a `MoveAuthenticator` as its signature
 /// scheme. It is evaluated during the authentication phase of a transaction and

--- a/iota_interaction/src/sdk_types/iota_types/iota_serde.rs
+++ b/iota_interaction/src/sdk_types/iota_types/iota_serde.rs
@@ -317,6 +317,7 @@ impl<T> Display for BigInt<T>
 
 #[serde_as]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Copy, JsonSchema)]
+#[schemars(rename = "SequenceNumberBigInt")]
 pub struct SequenceNumber(#[schemars(with = "BigInt<u64>")] u64);
 
 impl SerializeAs<super::base_types::SequenceNumber> for SequenceNumber {

--- a/product_common/Cargo.toml
+++ b/product_common/Cargo.toml
@@ -23,7 +23,7 @@ async-trait.workspace = true
 bcs = { workspace = true, optional = true }
 cfg-if.workspace = true
 fastcrypto = { workspace = true, optional = true }
-iota-keys = { package = "iota-keys", git = "https://github.com/iotaledger/iota.git", rev = "96196f0da231883ec69cda04892c600ef6afa982", optional = true }
+iota-keys = { package = "iota-keys", git = "https://github.com/iotaledger/iota.git", tag = "v1.22.1", optional = true }
 iota-sdk-types = { workspace = true, features = ["serde"] }
 itertools = { version = "0.13.0", optional = true }
 lazy_static = { version = "1.5.0", optional = true }


### PR DESCRIPTION
# Description of change

Following dependencies have been changed:
- [ ] tokio version update to: -
- [ ] fastcrypto version update to rev = "-"
- [x] iota-sdk-types (`https://github.com/iotaledger/iota-rust-sdk.git`) update to rev = 7c1434aabb2e7b11681722edaf1a51ac52941b84
- [x] changes in iota_interaction/src/sdk_types
- [ ] iota_interaction_ts: new peerDep. version for @iota/iota-sdk: _
- [x] pin all iota.git dependencies to `tag = "v1.22.1"`

## Links to any relevant issues

https://github.com/iotaledger/product-core/issues/67

## How the change has been tested

The changes have been tested using IOTA version "v1.22.1" with the following test PRs:

* Identity: https://github.com/iotaledger/identity/pull/1815
* Notarization: https://github.com/iotaledger/notarization/pull/258
