### PR TITLE
Upstream merge to iota v1.24.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ bcs = "0.1.6"
 cfg-if = "1.0.0"
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "69d496c71fb37e3d22fe85e5bbfd4256d61422b9", package = "fastcrypto" }
 hyper = "1"
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.23.2" }
-iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "c37fbcc9ad56c92f23582dcdb8203e3594088639", default-features = false }
-move-binary-format = { git = "https://github.com/iotaledger/iota.git", package = "move-binary-format", tag = "v1.23.2" }
-move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.23.2" }
-move-bytecode-utils = { git = "https://github.com/iotaledger/iota.git", package = "move-bytecode-utils", tag = "v1.23.2" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.24.0" }
+iota-sdk-types = { git = "https://github.com/iotaledger/iota-rust-sdk.git", rev = "cdf7afb2ce3d785f1622711ef1800b18eea391f4", default-features = false }
+move-binary-format = { git = "https://github.com/iotaledger/iota.git", package = "move-binary-format", tag = "v1.24.0" }
+move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.24.0" }
+move-bytecode-utils = { git = "https://github.com/iotaledger/iota.git", package = "move-bytecode-utils", tag = "v1.24.0" }
 phf = { version = "0.11.2", features = ["macros"] }
 secret-storage = { git = "https://github.com/iotaledger/secret-storage.git", default-features = false, tag = "v0.3.0" }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive", "rc"] }

--- a/iota_interaction/Cargo.toml
+++ b/iota_interaction/Cargo.toml
@@ -31,8 +31,8 @@ thiserror.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 hyper.workspace = true
-iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.23.2" }
-move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.23.2" }
+iota-sdk = { git = "https://github.com/iotaledger/iota.git", package = "iota-sdk", tag = "v1.24.0" }
+move-core-types = { git = "https://github.com/iotaledger/iota.git", package = "move-core-types", tag = "v1.24.0" }
 tokio = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/iota_interaction/src/sdk_types/error.rs
+++ b/iota_interaction/src/sdk_types/error.rs
@@ -18,7 +18,7 @@ pub enum Error {
     BcsSerialization(#[from] bcs::Error),
     #[error("Subscription error: {0}")]
     Subscription(String),
-    #[error("Failed to confirm tx status for {0:?} within {1} seconds.")]
+    #[error("Failed to confirm tx status for {0} within {1} seconds.")]
     FailToConfirmTransactionStatus(TransactionDigest, u64),
     #[error("Data error: {0}")]
     Data(String),

--- a/iota_interaction/src/sdk_types/iota_json_rpc_types/iota_object.rs
+++ b/iota_interaction/src/sdk_types/iota_json_rpc_types/iota_object.rs
@@ -10,12 +10,13 @@ use std::string::String;
 use anyhow::{anyhow, bail};
 use fastcrypto::encoding::Base64;
 use super::iota_move::{IotaMoveStruct, IotaMoveValue};
+use super::iota_object_response_error::IotaObjectResponseError;
 use super::Page;
 use crate::types::base_types::{
     Identifier, IotaAddress, ObjectID, ObjectInfo, ObjectRef, ObjectType,
     SequenceNumber, StructTag};
 use crate::types::digests::{ObjectDigest, TransactionDigest};
-use crate::types::error::{IotaObjectResponseError, UserInputError, UserInputResult};
+use crate::types::error::{UserInputError, UserInputResult};
 use crate::types::move_package::{MovePackage, TypeOrigin, UpgradeInfo};
 use crate::types::object::Owner;
 
@@ -31,13 +32,11 @@ use super::{
     },
 };
 
-#[serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct IotaObjectResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<IotaObjectData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde_as(as = "Option<IotaObjectResponseErrorSchema>")]
     pub error: Option<IotaObjectResponseError>,
 }
 
@@ -193,7 +192,7 @@ impl IotaObjectData {
     pub fn object_type(&self) -> anyhow::Result<ObjectType> {
         self.type_
             .as_ref()
-            .ok_or_else(|| anyhow!("type is missing for object {:?}", self.object_id))
+            .ok_or_else(|| anyhow!("type is missing for object {}", self.object_id))
             .cloned()
     }
 

--- a/iota_interaction/src/sdk_types/iota_json_rpc_types/iota_object_response_error.rs
+++ b/iota_interaction/src/sdk_types/iota_json_rpc_types/iota_object_response_error.rs
@@ -4,21 +4,36 @@
 use crate::types::{
     base_types::{ObjectID, SequenceNumber},
     digests::ObjectDigest,
-    error::IotaObjectResponseError as NativeObjectResponseError,
 };
 use serde::{Deserialize, Serialize};
-use serde_with::{DeserializeAs, SerializeAs, serde_as};
+use strum::{AsRefStr, IntoStaticStr};
+use thiserror::Error;
 
-#[serde_as]
-#[derive(Serialize, Deserialize)]
+#[derive(
+    Eq,
+    PartialEq,
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    Hash,
+    AsRefStr,
+    IntoStaticStr,
+    Error,
+)]
 #[serde(tag = "code", rename = "ObjectResponseError", rename_all = "camelCase")]
 pub enum IotaObjectResponseError {
+    #[error("Object {object_id} does not exist")]
     NotExists {
         object_id: ObjectID,
     },
+    #[error("Cannot find dynamic field for parent object {parent_object_id}")]
     DynamicFieldNotFound {
         parent_object_id: ObjectID,
     },
+    #[error(
+        "Object has been deleted object_id: {object_id} at version: {version} in digest {digest}"
+    )]
     Deleted {
         object_id: ObjectID,
         /// Object version.
@@ -26,71 +41,8 @@ pub enum IotaObjectResponseError {
         /// Base64 string representing the object digest
         digest: ObjectDigest,
     },
+    #[error("Unknown Error")]
     Unknown,
-    Display {
-        error: String,
-    },
-}
-
-impl SerializeAs<NativeObjectResponseError> for IotaObjectResponseError {
-    fn serialize_as<S>(source: &NativeObjectResponseError, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        IotaObjectResponseError::from(source.clone()).serialize(serializer)
-    }
-}
-
-impl<'de> DeserializeAs<'de, NativeObjectResponseError> for IotaObjectResponseError {
-    fn deserialize_as<D>(deserializer: D) -> Result<NativeObjectResponseError, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let schema = IotaObjectResponseError::deserialize(deserializer)?;
-        Ok(NativeObjectResponseError::from(schema))
-    }
-}
-
-impl From<NativeObjectResponseError> for IotaObjectResponseError {
-    fn from(error: NativeObjectResponseError) -> Self {
-        match error {
-            NativeObjectResponseError::NotExists { object_id } => Self::NotExists { object_id },
-            NativeObjectResponseError::DynamicFieldNotFound { parent_object_id } => {
-                Self::DynamicFieldNotFound { parent_object_id }
-            }
-            NativeObjectResponseError::Deleted {
-                object_id,
-                version,
-                digest,
-            } => Self::Deleted {
-                object_id,
-                version,
-                digest,
-            },
-            NativeObjectResponseError::Unknown => Self::Unknown,
-            NativeObjectResponseError::Display { error } => Self::Display { error },
-        }
-    }
-}
-
-impl From<IotaObjectResponseError> for NativeObjectResponseError {
-    fn from(error: IotaObjectResponseError) -> Self {
-        match error {
-            IotaObjectResponseError::NotExists { object_id } => Self::NotExists { object_id },
-            IotaObjectResponseError::DynamicFieldNotFound { parent_object_id } => {
-                Self::DynamicFieldNotFound { parent_object_id }
-            }
-            IotaObjectResponseError::Deleted {
-                object_id,
-                version,
-                digest,
-            } => Self::Deleted {
-                object_id,
-                version,
-                digest,
-            },
-            IotaObjectResponseError::Unknown => Self::Unknown,
-            IotaObjectResponseError::Display { error } => Self::Display { error },
-        }
-    }
+    #[error("Display Error: {error}")]
+    Display { error: String },
 }

--- a/iota_interaction/src/sdk_types/iota_json_rpc_types/iota_transaction.rs
+++ b/iota_interaction/src/sdk_types/iota_json_rpc_types/iota_transaction.rs
@@ -464,7 +464,9 @@ impl From<ExecutionStatus> for IotaExecutionStatus {
             } => Self::Failure {
                 error: format!("{error} in command {idx}"),
             },
-            _ => unimplemented!("a new enum variant was added and needs to be handled"),
+            _ => unimplemented!(
+                "a new ExecutionStatus enum variant was added and needs to be handled"
+            ),
         }
     }
 }

--- a/iota_interaction/src/sdk_types/iota_json_rpc_types/mod.rs
+++ b/iota_interaction/src/sdk_types/iota_json_rpc_types/mod.rs
@@ -12,11 +12,14 @@ pub mod iota_owner;
 pub mod iota_primitives;
 pub mod iota_transaction;
 
-pub use iota_transaction::*;
-pub use iota_object::*;
 pub use iota_coin::*;
 pub use iota_event::*;
 pub use iota_move::*;
+pub use iota_object::*;
+pub use iota_object_response_error::*;
+pub use iota_owner::*;
+pub use iota_primitives::*;
+pub use iota_transaction::*;
 
 use serde::{Deserialize, Serialize};
 
@@ -26,7 +29,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Page<T, C> {
-    pub data: Vec<T>,
-    pub next_cursor: Option<C>,
-    pub has_next_page: bool,
+  pub data: Vec<T>,
+  pub next_cursor: Option<C>,
+  pub has_next_page: bool,
 }

--- a/iota_interaction/src/sdk_types/iota_types/auth_context/mod.rs
+++ b/iota_interaction/src/sdk_types/iota_types/auth_context/mod.rs
@@ -14,7 +14,9 @@ use crate::move_core_types::{
 use serde::Serialize;
 
 use crate::types::{
-    IOTA_FRAMEWORK_ADDRESS, digests::MoveAuthenticatorDigest, transaction::ProgrammableTransaction,
+    IOTA_FRAMEWORK_ADDRESS,
+    digests::{Digest, MoveAuthenticatorDigest},
+    transaction::ProgrammableTransaction,
 };
 
 pub const AUTH_CONTEXT_MODULE_NAME: &IdentStr = ident_str!("auth_context");
@@ -36,7 +38,7 @@ pub const AUTH_CONTEXT_STRUCT_NAME: &IdentStr = ident_str!("AuthContext");
 ///
 /// Typical use:
 /// ```move
-/// public fun authenticate(account: &Account, signature: &vector<u8>, auth_ctx: &AuthContext, , ctx: &TxContext) {
+/// public fun authenticate(account: &Account, signature: &vector<u8>, auth_ctx: &AuthContext, ctx: &TxContext) {
 ///     assert!(ed25519::ed25519_verify(signature, &account.pub_key, ctx.digest()), EEd25519VerificationFailed);
 ///     
 ///     assert!(is_authorized(&extract_function_key(&auth_ctx)), EUnauthorized);
@@ -49,6 +51,15 @@ pub const AUTH_CONTEXT_STRUCT_NAME: &IdentStr = ident_str!("AuthContext");
 pub struct AuthContext {
     /// The digest of the MoveAuthenticator
     auth_digest: MoveAuthenticatorDigest,
+    /// The sender's auth digest. For [`MoveAuthenticator`] signatures equals
+    /// [`MoveAuthenticator::digest()`]; for others Blake2b256 of the
+    /// serialized (flag-prefixed) signature bytes.
+    sender_auth_digest: Digest,
+    /// The sponsor's auth digest, present only for sponsored transactions.
+    /// For [`MoveAuthenticator`] signatures equals
+    /// [`MoveAuthenticator::digest()`]; for others Blake2b256 of the
+    /// serialized (flag-prefixed) signature bytes.
+    sponsor_auth_digest: Option<Digest>,
     /// The authentication input objects or primitive values
     tx_inputs: Vec<MoveCallArg>,
     /// The authentication commands to be executed sequentially.
@@ -60,11 +71,15 @@ pub struct AuthContext {
 impl AuthContext {
     pub fn new_from_components(
         auth_digest: MoveAuthenticatorDigest,
+        sender_auth_digest: Digest,
+        sponsor_auth_digest: Option<Digest>,
         ptb: &ProgrammableTransaction,
         tx_data_bytes: Vec<u8>,
     ) -> Self {
         Self {
             auth_digest,
+            sender_auth_digest,
+            sponsor_auth_digest,
             tx_inputs: ptb.inputs.iter().map(MoveCallArg::from).collect(),
             tx_commands: ptb.commands.iter().map(MoveCommand::from).collect(),
             tx_data_bytes,
@@ -74,14 +89,36 @@ impl AuthContext {
     pub fn new_for_testing() -> Self {
         Self {
             auth_digest: MoveAuthenticatorDigest::default(),
+            sender_auth_digest: Digest::default(),
+            sponsor_auth_digest: None,
             tx_inputs: Vec::new(),
             tx_commands: Vec::new(),
             tx_data_bytes: Vec::new(),
         }
     }
 
+    /// Returns the MoveAuthenticator digest.
     pub fn digest(&self) -> &MoveAuthenticatorDigest {
         &self.auth_digest
+    }
+
+    /// Returns the sender's auth digest. For
+    /// [`MoveAuthenticator`](crate::move_authenticator::MoveAuthenticator)
+    /// signatures equals
+    /// [`MoveAuthenticator::digest()`](crate::move_authenticator::MoveAuthenticator::digest);
+    /// for others Blake2b256 of the serialized (flag-prefixed) signature bytes.
+    pub fn sender_auth_digest(&self) -> &Digest {
+        &self.sender_auth_digest
+    }
+
+    /// Returns the sponsor's auth digest for sponsored transactions, `None`
+    /// otherwise. For
+    /// [`MoveAuthenticator`](crate::move_authenticator::MoveAuthenticator)
+    /// signatures equals
+    /// [`MoveAuthenticator::digest()`](crate::move_authenticator::MoveAuthenticator::digest);
+    /// for others Blake2b256 of the serialized (flag-prefixed) signature bytes.
+    pub fn sponsor_auth_digest(&self) -> Option<&Digest> {
+        self.sponsor_auth_digest.as_ref()
     }
 
     pub fn tx_inputs(&self) -> &Vec<MoveCallArg> {
@@ -146,11 +183,15 @@ impl AuthContext {
         tx_inputs: Vec<MoveCallArg>,
         tx_commands: Vec<MoveCommand>,
         tx_data_bytes: Vec<u8>,
+        sender_auth_digest: Digest,
+        sponsor_auth_digest: Option<Digest>,
     ) {
         self.auth_digest = auth_digest;
         self.tx_inputs = tx_inputs;
         self.tx_commands = tx_commands;
         self.tx_data_bytes = tx_data_bytes;
+        self.sender_auth_digest = sender_auth_digest;
+        self.sponsor_auth_digest = sponsor_auth_digest;
     }
 }
 

--- a/iota_interaction/src/sdk_types/iota_types/crypto.rs
+++ b/iota_interaction/src/sdk_types/iota_types/crypto.rs
@@ -604,7 +604,7 @@ impl<S: IotaSignatureInner + Sized> IotaSignature for S {
         let address = address_from_iota_pub_key(pk);
         if author != address {
             return Err(IotaError::IncorrectSigner {
-                error: format!("Incorrect signer, expected {author:?}, got {address:?}"),
+                error: format!("Incorrect signer, expected {author}, got {address}"),
             });
         }
 

--- a/iota_interaction/src/sdk_types/iota_types/digests.rs
+++ b/iota_interaction/src/sdk_types/iota_types/digests.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_sdk_types::Digest;
+pub use iota_sdk_types::Digest;
 
 pub type CheckpointDigest = Digest;
 pub type CheckpointContentsDigest = Digest;

--- a/iota_interaction/src/sdk_types/iota_types/error.rs
+++ b/iota_interaction/src/sdk_types/iota_types/error.rs
@@ -3,7 +3,7 @@
 // Modifications Copyright (c) 2024 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, fmt::Debug};
+use std::{collections::BTreeMap, convert::AsRef, fmt::Debug};
 
 use serde::{Deserialize, Serialize};
 use strum::{AsRefStr, IntoStaticStr};
@@ -84,11 +84,7 @@ pub enum UserInputError {
     MutableObjectUsedMoreThanOnce { object_id: ObjectID },
     #[error("Wrong number of parameters for the transaction")]
     ObjectInputArityViolation,
-    #[error(
-        "Could not find the referenced object {:?} at version {:?}",
-        object_id,
-        version
-    )]
+    #[error("Could not find the referenced object {object_id} at version {version:?}")]
     ObjectNotFound {
         object_id: ObjectID,
         version: Option<SequenceNumber>,
@@ -101,25 +97,23 @@ pub enum UserInputError {
         provided_obj_ref: ObjectRef,
         current_version: SequenceNumber,
     },
-    #[error("Package verification failed: {err:?}")]
+    #[error("Package verification failed: {err}")]
     PackageVerificationTimedout { err: String },
-    #[error("Dependent package not found on-chain: {package_id:?}")]
+    #[error("Dependent package not found on-chain: {package_id}")]
     DependentPackageNotFound { package_id: ObjectID },
     #[error("Mutable parameter provided, immutable parameter expected")]
     ImmutableParameterExpected { object_id: ObjectID },
     #[error("Size limit exceeded: {limit} is {value}")]
     SizeLimitExceeded { limit: String, value: String },
     #[error(
-        "Object {child_id:?} is owned by object {parent_id:?}. \
+        "Object {child_id} is owned by object {parent_id}. \
         Objects owned by other objects cannot be used as input arguments"
     )]
     InvalidChildObjectArgument {
         child_id: ObjectID,
         parent_id: ObjectID,
     },
-    #[error(
-        "Invalid Object digest for object {object_id:?}. Expected digest : {expected_digest:?}"
-    )]
+    #[error("Invalid Object digest for object {object_id}. Expected digest : {expected_digest}")]
     InvalidObjectDigest {
         object_id: ObjectID,
         expected_digest: ObjectDigest,
@@ -143,14 +137,14 @@ pub enum UserInputError {
     // Gas related errors
     #[error("Transaction gas payment missing")]
     MissingGasPayment,
-    #[error("Gas object is not an owned object with owner: {:?}", owner)]
+    #[error("Gas object is not an owned object with owner: {}", owner)]
     GasObjectNotOwnedObject { owner: Owner },
-    #[error("Gas budget: {:?} is higher than max: {:?}", gas_budget, max_budget)]
+    #[error("Gas budget: {} is higher than max: {}", gas_budget, max_budget)]
     GasBudgetTooHigh { gas_budget: u64, max_budget: u64 },
-    #[error("Gas budget: {:?} is lower than min: {:?}", gas_budget, min_budget)]
+    #[error("Gas budget: {} is lower than min: {}", gas_budget, min_budget)]
     GasBudgetTooLow { gas_budget: u64, min_budget: u64 },
     #[error(
-        "Balance of gas object {:?} is lower than the needed amount: {:?}",
+        "Balance of gas object {} is lower than the needed amount: {}",
         gas_balance,
         needed_gas_amount
     )]
@@ -161,7 +155,7 @@ pub enum UserInputError {
     #[error("Transaction kind does not support Sponsored Transaction")]
     UnsupportedSponsoredTransactionKind,
     #[error(
-        "Gas price {:?} under reference gas price (RGP) {:?}",
+        "Gas price {} under reference gas price (RGP) {}",
         gas_price,
         reference_gas_price
     )]
@@ -169,7 +163,7 @@ pub enum UserInputError {
         gas_price: u64,
         reference_gas_price: u64,
     },
-    #[error("Gas price cannot exceed {:?} nanos", max_gas_price)]
+    #[error("Gas price cannot exceed {} nanos", max_gas_price)]
     GasPriceTooHigh { max_gas_price: u64 },
     #[error("Object {object_id} is not a gas object")]
     InvalidGasObject { object_id: ObjectID },
@@ -177,7 +171,7 @@ pub enum UserInputError {
     InsufficientBalanceToCoverMinimalGas,
 
     #[error(
-        "Could not find the referenced object {:?} as the asked version {:?} is higher than the latest {:?}",
+        "Could not find the referenced object {} as the asked version {} is higher than the latest {}",
         object_id,
         asked_version,
         latest_version
@@ -195,7 +189,7 @@ pub enum UserInputError {
     BlockedMoveFunction,
     #[error("Empty input coins for Pay related transaction")]
     EmptyInputCoins,
-    #[error("Invalid Move View Function call: {error:?}")]
+    #[error("Invalid Move View Function call: {error}")]
     InvalidMoveViewFunction { error: String },
 
     #[error(
@@ -220,7 +214,7 @@ pub enum UserInputError {
     )]
     EmptyCommandInput,
 
-    #[error("Transaction is denied: {}", error)]
+    #[error("Transaction is denied: {error}")]
     TransactionDenied { error: String },
 
     #[error("Feature is not supported: {0}")]
@@ -247,10 +241,7 @@ pub enum UserInputError {
     #[error("Transaction {0} not found")]
     TransactionCursorNotFound(u64),
 
-    #[error(
-        "Object {:?} is a system object and cannot be accessed by user transactions",
-        object_id
-    )]
+    #[error("Object {object_id} is a system object and cannot be accessed by user transactions")]
     InaccessibleSystemObject { object_id: ObjectID },
     #[error(
         "{max_publish_commands} max publish/upgrade commands allowed, {publish_count} provided"
@@ -260,7 +251,7 @@ pub enum UserInputError {
         publish_count: u64,
     },
 
-    #[error("Immutable parameter provided, mutable parameter expected")]
+    #[error("Immutable parameter provided, mutable parameter expected for {object_id}")]
     MutableParameterExpected { object_id: ObjectID },
 
     #[error("Address {address} is denied for coin {coin_type}")]
@@ -273,28 +264,20 @@ pub enum UserInputError {
     PostRandomCommandRestrictions,
 
     // Soft Bundle related errors
-    #[error(
-        "Number of transactions exceeds the maximum allowed ({:?}) in a Soft Bundle",
-        limit
-    )]
+    #[error("Number of transactions exceeds the maximum allowed ({limit}) in a Soft Bundle")]
     TooManyTransactionsInSoftBundle { limit: u64 },
     #[error(
-        "Total transactions size ({:?})bytes exceeds the maximum allowed ({:?})bytes in a Soft Bundle",
-        size,
-        limit
+        "Total transactions size ({size}) bytes exceeds the maximum allowed ({limit}) bytes in a Soft Bundle"
     )]
     SoftBundleTooLarge { size: u64, limit: u64 },
-    #[error("Transaction {:?} in Soft Bundle contains no shared objects", digest)]
+    #[error("Transaction {} in Soft Bundle contains no shared objects", digest)]
     NoSharedObject { digest: TransactionDigest },
-    #[error("Transaction {:?} in Soft Bundle has already been executed", digest)]
+    #[error("Transaction {} in Soft Bundle has already been executed", digest)]
     AlreadyExecuted { digest: TransactionDigest },
     #[error("At least one certificate in Soft Bundle has already been processed")]
     CertificateAlreadyProcessed,
     #[error(
-        "Gas price for transaction {:?} in Soft Bundle mismatch: want {:?}, have {:?}",
-        digest,
-        expected,
-        actual
+        "Gas price for transaction {digest} in Soft Bundle mismatch: want {expected}, have {actual}"
     )]
     GasPriceMismatch {
         digest: TransactionDigest,
@@ -310,7 +293,7 @@ pub enum UserInputError {
 
     // `MoveAuthenticator` related errors
     #[error(
-        "Account object {account_id:?} with version {account_version:?} was deleted in transaction {transaction_digest:?}"
+        "Account object {account_id} with version {account_version} was deleted in transaction {transaction_digest}"
     )]
     AccountObjectDeleted {
         account_id: ObjectID,
@@ -318,16 +301,16 @@ pub enum UserInputError {
         transaction_digest: TransactionDigest,
     },
     #[error(
-        "Account object {account_id:?} with version {account_version:?} is used in a canceled transaction"
+        "Account object {account_id} with version {account_version} is used in a canceled transaction"
     )]
     AccountObjectInCanceledTransaction {
         account_id: ObjectID,
         account_version: SequenceNumber,
     },
-    #[error("Account object {object_id:?} is not a shared or immutable object that is unsupported")]
+    #[error("Account object {object_id} is not a shared or immutable object that is unsupported")]
     AccountObjectNotSupported { object_id: ObjectID },
     #[error(
-        "The fetched account object version {actual_version:?} does not match the expected version {expected_version:?}, object id: {object_id:?}"
+        "The fetched account object version {actual_version} does not match the expected version {expected_version}, object id: {object_id}"
     )]
     AccountObjectVersionMismatch {
         object_id: ObjectID,
@@ -335,7 +318,7 @@ pub enum UserInputError {
         actual_version: SequenceNumber,
     },
     #[error(
-        "The fetched account object digest {actual_digest:?} does not match the expected digest {expected_digest:?}, object id: {object_id:?}"
+        "The fetched account object digest {actual_digest} does not match the expected digest {expected_digest}, object id: {object_id}"
     )]
     InvalidAccountObjectDigest {
         object_id: ObjectID,
@@ -344,63 +327,34 @@ pub enum UserInputError {
     },
 
     #[error(
-        "AuthenticatorFunctionRef {authenticator_function_ref_id:?} not found for account {account_object_id:?} with version {account_object_version:?}"
+        "AuthenticatorFunctionRef {authenticator_function_ref_id} not found for account {account_object_id} with version {account_object_version}"
     )]
     MoveAuthenticatorNotFound {
         authenticator_function_ref_id: ObjectID,
         account_object_id: ObjectID,
         account_object_version: SequenceNumber,
     },
-    #[error("Unable to get a Move authenticator object ID for account {account_object_id:?}")]
+    #[error("Unable to get a `MoveAuthenticator` object ID for account {account_object_id}")]
     UnableToGetMoveAuthenticatorId { account_object_id: ObjectID },
     #[error(
-        "Invalid authenticator function ref field value found for the account {account_object_id:?}"
+        "Invalid authenticator function ref field value found for the account {account_object_id}"
     )]
     InvalidAuthenticatorFunctionRefField { account_object_id: ObjectID },
 
-    #[error("Package {package_id:?} is in the `MoveAuthenticator` input that is unsupported")]
+    #[error("Package {package_id} is in the `MoveAuthenticator` input that is unsupported")]
     PackageIsInMoveAuthenticatorInput { package_id: ObjectID },
     #[error(
-        "Address-owned object {object_id:?} is in the `MoveAuthenticator` input that is unsupported"
+        "Address-owned object {object_id} is in the `MoveAuthenticator` input that is unsupported"
     )]
     AddressOwnedIsInMoveAuthenticatorInput { object_id: ObjectID },
     #[error(
-        "Object-owned object {object_id:?} is in the `MoveAuthenticator` input that is unsupported"
+        "Object-owned object {object_id} is in the `MoveAuthenticator` input that is unsupported"
     )]
     ObjectOwnedIsInMoveAuthenticatorInput { object_id: ObjectID },
     #[error(
-        "Mutable shared object {object_id:?} is in the `MoveAuthenticator` input that is unsupported"
+        "Mutable shared object {object_id} is in the `MoveAuthenticator` input that is unsupported"
     )]
     MutableSharedIsInMoveAuthenticatorInput { object_id: ObjectID },
-}
-
-#[derive(
-    Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Hash, AsRefStr, IntoStaticStr, Error,
-)]
-#[serde(tag = "code", rename = "ObjectResponseError", rename_all = "camelCase")]
-pub enum IotaObjectResponseError {
-    #[error("Object {:?} does not exist", object_id)]
-    NotExists { object_id: ObjectID },
-    #[error("Cannot find dynamic field for parent object {:?}", parent_object_id)]
-    DynamicFieldNotFound { parent_object_id: ObjectID },
-    #[error(
-        "Object has been deleted object_id: {:?} at version: {:?} in digest {:?}",
-        object_id,
-        version,
-        digest
-    )]
-    Deleted {
-        object_id: ObjectID,
-        /// Object version.
-        version: SequenceNumber,
-        /// Base64 string representing the object digest
-        digest: ObjectDigest,
-    },
-    #[error("Unknown Error")]
-    Unknown,
-    #[error("Display Error: {:?}", error)]
-    Display { error: String },
-    // TODO: also integrate IotaPastObjectResponse (VersionNotFound,  VersionTooHigh)
 }
 
 /// Custom error type for Iota.
@@ -410,9 +364,6 @@ pub enum IotaObjectResponseError {
 pub enum IotaError {
     #[error("Error checking transaction input objects: {error}")]
     UserInput { error: UserInputError },
-
-    #[error("Error checking transaction object: {error}")]
-    IotaObjectResponse { error: IotaObjectResponseError },
 
     #[error("There are already {queue_len} transactions pending, above threshold of {threshold}")]
     TooManyTransactionsPendingExecution { queue_len: usize, threshold: usize },
@@ -444,7 +395,7 @@ pub enum IotaError {
     // Signature verification
     #[error("Signature is not valid: {}", error)]
     InvalidSignature { error: String },
-    #[error("Required Signature from {expected} is absent {:?}", actual)]
+    #[error("Required Signature from {expected} is absent {actual:?}")]
     SignerSignatureAbsent {
         expected: String,
         actual: Vec<String>,
@@ -464,9 +415,7 @@ pub enum IotaError {
         committee: Box<String>, // Committee is not available for wasm32
     },
     #[error(
-        "Validator {:?} responded multiple signatures for the same message, conflicting: {:?}",
-        signer,
-        conflicting_sig
+        "Validator {signer:?} responded multiple signatures for the same message, conflicting: {conflicting_sig}"
     )]
     StakeAggregatorRepeatedSigner {
         signer: AuthorityName,
@@ -474,10 +423,7 @@ pub enum IotaError {
     },
     // TODO: Used for distinguishing between different occurrences of invalid signatures, to allow
     // retries in some cases.
-    #[error(
-        "Signature is not valid, but a retry may result in a valid one: {}",
-        error
-    )]
+    #[error("Signature is not valid, but a retry may result in a valid one: {error}")]
     PotentiallyTemporarilyInvalidSignature { error: String },
 
     // Certificate verification and execution
@@ -500,7 +446,7 @@ pub enum IotaError {
         effects_map: BTreeMap<TransactionEffectsDigest, (Vec<AuthorityName>, StakeUnit)>,
     },
     #[error(
-        "Failed to verify Tx certificate with executed effects, error: {error:?}, validator: {validator_name:?}"
+        "Failed to verify Tx certificate with executed effects, error: {error}, validator: {validator_name:?}"
     )]
     FailedToVerifyTxCertWithExecutedEffects {
         validator_name: AuthorityName,
@@ -514,9 +460,9 @@ pub enum IotaError {
     InvalidAuthenticator,
     #[error("Invalid address")]
     InvalidAddress,
-    #[error("Invalid transaction digest.")]
+    #[error("Invalid transaction digest")]
     InvalidTransactionDigest,
-    #[error("Invalid move authentication digest.")]
+    #[error("Invalid move authentication digest")]
     InvalidMoveAuthenticatorDigest,
 
     #[error("Invalid digest length. Expected {expected}, got {actual}")]
@@ -524,38 +470,36 @@ pub enum IotaError {
     #[error("Invalid DKG message size")]
     InvalidDkgMessageSize,
 
-    #[error("Unexpected message.")]
+    #[error("Unexpected message")]
     UnexpectedMessage,
 
-    #[error("Failed to execute the Move authenticator, reason: {error:?}.")]
+    #[error("Failed to execute the Move authenticator, reason: {error}")]
     MoveAuthenticatorExecutionFailure { error: String },
 
     // Move module publishing related errors
-    #[error("Failed to verify the Move module, reason: {error:?}.")]
+    #[error("Failed to verify the Move module, reason: {error}")]
     ModuleVerificationFailure { error: String },
-    #[error("Failed to deserialize the Move module, reason: {error:?}.")]
+    #[error("Failed to deserialize the Move module, reason: {error}")]
     ModuleDeserializationFailure { error: String },
     #[error("Failed to publish the Move module(s), reason: {error}")]
     ModulePublishFailure { error: String },
-    #[error("Failed to build Move modules: {error}.")]
+    #[error("Failed to build Move modules: {error}")]
     ModuleBuildFailure { error: String },
 
     // Move call related errors
-    #[error("Function resolution failure: {error:?}.")]
+    #[error("Function resolution failure: {error}")]
     FunctionNotFound { error: String },
-    #[error("Module not found in package: {module_name:?}.")]
+    #[error("Module not found in package: {module_name:?}")]
     ModuleNotFound { module_name: String },
-    #[error("Type error while binding function arguments: {error:?}.")]
+    #[error("Type error while binding function arguments: {error}")]
     Type { error: String },
     #[error("Circular object ownership detected")]
     CircularObjectOwnership,
 
     // Internal state errors
-    #[error("Attempt to re-initialize a transaction lock for objects {:?}.", refs)]
+    #[error("Attempt to re-initialize a transaction lock for objects {refs:?}")]
     ObjectLockAlreadyInitialized { refs: Vec<ObjectRef> },
-    #[error(
-        "Object {obj_ref:?} already locked by a different transaction: {pending_transaction:?}"
-    )]
+    #[error("Object {obj_ref:?} already locked by a different transaction: {pending_transaction}")]
     ObjectLockConflict {
         obj_ref: ObjectRef,
         pending_transaction: TransactionDigest,
@@ -569,15 +513,14 @@ pub enum IotaError {
         new_epoch: EpochId,
         locked_by_tx: TransactionDigest,
     },
-    #[error("{TRANSACTION_NOT_FOUND_MSG_PREFIX} [{:?}].", digest)]
+    #[error("{TRANSACTION_NOT_FOUND_MSG_PREFIX} [{digest}]")]
     TransactionNotFound { digest: TransactionDigest },
-    #[error("{TRANSACTIONS_NOT_FOUND_MSG_PREFIX} [{:?}].", digests)]
+    #[error("{TRANSACTIONS_NOT_FOUND_MSG_PREFIX} [{digests:?}]")]
     TransactionsNotFound { digests: Vec<TransactionDigest> },
-    #[error("Could not find the referenced transaction events [{digest:?}].")]
+    #[error("Could not find the referenced transaction events [{digest}]")]
     TransactionEventsNotFound { digest: TransactionDigest },
     #[error(
-        "Attempt to move to `Executed` state an transaction that has already been executed: {:?}.",
-        digest
+        "Attempt to move to `Executed` state an transaction that has already been executed: {digest}"
     )]
     TransactionAlreadyExecuted { digest: TransactionDigest },
     #[error("Object ID did not have the expected type")]
@@ -587,7 +530,7 @@ pub enum IotaError {
 
     #[error("Execution invariant violated")]
     ExecutionInvariantViolation,
-    #[error("Validator {authority:?} is faulty in a Byzantine manner: {reason:?}")]
+    #[error("Validator {authority:?} is faulty in a Byzantine manner: {reason}")]
     ByzantineAuthoritySuspicion {
         authority: AuthorityName,
         reason: String,
@@ -602,43 +545,40 @@ pub enum IotaError {
         actual_owner: Owner,
     },
 
-    #[error("Authority Error: {error:?}")]
+    #[error("Authority Error: {error}")]
     GenericAuthority { error: String },
 
-    #[error("Failed to dispatch subscription: {error:?}")]
+    #[error("Failed to dispatch subscription: {error}")]
     FailedToDispatchSubscription { error: String },
 
-    #[error("Failed to serialize Owner: {error:?}")]
+    #[error("Failed to serialize Owner: {error}")]
     OwnerFailedToSerialize { error: String },
 
-    #[error("Failed to deserialize fields into JSON: {error:?}")]
+    #[error("Failed to deserialize fields into JSON: {error}")]
     ExtraFieldFailedToDeserialize { error: String },
 
-    #[error("Failed to execute transaction locally by Orchestrator: {error:?}")]
+    #[error("Failed to execute transaction locally by Orchestrator: {error}")]
     TransactionOrchestratorLocalExecution { error: String },
 
     // Errors returned by authority and client read API's
-    #[error("Failure serializing transaction in the requested format: {:?}", error)]
+    #[error("Failure serializing transaction in the requested format: {error}")]
     TransactionSerialization { error: String },
-    #[error("Failure serializing object in the requested format: {:?}", error)]
+    #[error("Failure serializing object in the requested format: {error}")]
     ObjectSerialization { error: String },
-    #[error("Failure deserializing object in the requested format: {:?}", error)]
+    #[error("Failure deserializing object in the requested format: {error}")]
     ObjectDeserialization { error: String },
-    #[error(
-        "Failure deserializing runtime module metadata in the requested format: {:?}",
-        error
-    )]
+    #[error("Failure deserializing runtime module metadata in the requested format: {error}")]
     RuntimeModuleMetadataDeserialization { error: String },
     #[error("Event store component is not active on this node")]
     NoEventStore,
 
     // Client side error
-    #[error("Too many authority errors were detected for {}: {:?}", action, errors)]
+    #[error("Too many authority errors were detected for {action}: {errors:?}")]
     TooManyIncorrectAuthorities {
         errors: Vec<(AuthorityName, IotaError)>,
         action: String,
     },
-    #[error("Invalid transaction range query to the fullnode: {:?}", error)]
+    #[error("Invalid transaction range query to the fullnode: {error}")]
     FullNodeInvalidTxRangeQuery { error: String },
 
     // Errors related to the authority-consensus interface.
@@ -668,7 +608,7 @@ pub enum IotaError {
     ValidatorHaltedAtEpochEnd,
     #[error("Operations for epoch {0} have ended")]
     EpochEnded(EpochId),
-    #[error("Error when advancing epoch: {:?}", error)]
+    #[error("Error when advancing epoch: {error}")]
     AdvanceEpoch { error: String },
 
     #[error("Transaction Expired")]
@@ -683,10 +623,10 @@ pub enum IotaError {
     InvalidRpcMethod,
 
     // TODO: We should fold this into UserInputError::Unsupported.
-    #[error("Use of disabled feature: {:?}", error)]
+    #[error("Use of disabled feature: {error}")]
     UnsupportedFeature { error: String },
 
-    #[error("Unable to communicate with the Quorum Driver channel: {:?}", error)]
+    #[error("Unable to communicate with the Quorum Driver channel: {error}")]
     QuorumDriverCommunication { error: String },
 
     #[error("Operation timed out")]
@@ -701,7 +641,7 @@ pub enum IotaError {
     #[error("Missing committee information for epoch {0}")]
     MissingCommitteeAtEpoch(EpochId),
 
-    #[error("Index store not available on this Fullnode.")]
+    #[error("Index store not available on this Fullnode")]
     IndexStoreNotAvailable,
 
     #[error("Failed to read dynamic field from table in the object store: {0}")]
@@ -729,7 +669,7 @@ pub enum IotaError {
     Storage(String),
 
     #[error(
-        "Validator cannot handle the request at the moment. Please retry after at least {retry_after_secs} seconds."
+        "Validator cannot handle the request at the moment. Please retry after at least {retry_after_secs} seconds"
     )]
     ValidatorOverloadedRetryAfter { retry_after_secs: u64 },
 
@@ -806,7 +746,7 @@ impl TryFrom<IotaError> for UserInputError {
     fn try_from(err: IotaError) -> Result<Self, Self::Error> {
         match err {
             IotaError::UserInput { error } => Ok(error),
-            other => anyhow::bail!("error {:?} is not UserInput", other),
+            other => anyhow::bail!("error `{other}` is not UserInput"),
         }
     }
 }
@@ -814,12 +754,6 @@ impl TryFrom<IotaError> for UserInputError {
 impl From<UserInputError> for IotaError {
     fn from(error: UserInputError) -> Self {
         IotaError::UserInput { error }
-    }
-}
-
-impl From<IotaObjectResponseError> for IotaError {
-    fn from(error: IotaObjectResponseError) -> Self {
-        IotaError::IotaObjectResponse { error }
     }
 }
 
@@ -994,7 +928,14 @@ impl ExecutionError {
 
 impl std::fmt::Display for ExecutionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ExecutionError: {self:?}")
+        write!(f, "{}: {}", self.inner.kind.as_ref(), self.inner.kind)?;
+        if let Some(source) = self.inner.source.as_ref() {
+            write!(f, "; caused by: {source}")?;
+        }
+        if let Some(command) = self.inner.command {
+            write!(f, "; at command index: {command}")?;
+        }
+        Ok(())
     }
 }
 

--- a/iota_interaction/src/sdk_types/iota_types/programmable_transaction_builder.rs
+++ b/iota_interaction/src/sdk_types/iota_types/programmable_transaction_builder.rs
@@ -87,11 +87,7 @@ impl ProgrammableTransactionBuilder {
                         id1 == id2 && id == id2,
             "invariant violation! object has id does not match call arg"
           );
-                    CallArg::Shared(SharedObjectRef {
-                        object_id: id,
-            initial_shared_version: v2,
-                        mutable: mut1 || mut2,
-                    })
+                    CallArg::Shared(SharedObjectRef::new(id, v2, mut1 || mut2))
           }
                 _ => {
           anyhow::ensure!(
@@ -115,7 +111,7 @@ impl ProgrammableTransactionBuilder {
             CallArg::ImmutableOrOwned(_) | CallArg::Shared(_) | CallArg::Receiving(_) => {
                 self.obj(call_arg)
             }
-            _ => unimplemented!("a new CallArg variant was added and needs to be handled"),
+            _ => unimplemented!("a new CallArg enum variant was added and needs to be handled"),
     }
   }
 

--- a/iota_interaction/src/sdk_types/iota_types/transaction.rs
+++ b/iota_interaction/src/sdk_types/iota_types/transaction.rs
@@ -96,28 +96,28 @@ impl TransactionDataAPI for TransactionData {
     fn sender(&self) -> IotaAddress {
         match self {
             Self::V1(v1) => v1.sender,
-            _ => unimplemented!("a new Transaction variant was added and needs to be handled"),
+            _ => unimplemented!("a new Transaction enum variant was added and needs to be handled"),
         }
     }
 
     fn kind(&self) -> &TransactionKind {
         match self {
             Self::V1(v1) => &v1.kind,
-            _ => unimplemented!("a new Transaction variant was added and needs to be handled"),
+            _ => unimplemented!("a new Transaction enum variant was added and needs to be handled"),
         }
     }
 
     fn kind_mut(&mut self) -> &mut TransactionKind {
         match self {
             Self::V1(v1) => &mut v1.kind,
-            _ => unimplemented!("a new Transaction variant was added and needs to be handled"),
+            _ => unimplemented!("a new Transaction enum variant was added and needs to be handled"),
         }
     }
 
     fn into_kind(self) -> TransactionKind {
         match self {
             Self::V1(v1) => v1.kind,
-            _ => unimplemented!("a new Transaction variant was added and needs to be handled"),
+            _ => unimplemented!("a new Transaction enum variant was added and needs to be handled"),
         }
     }
 
@@ -132,7 +132,7 @@ impl TransactionDataAPI for TransactionData {
     fn gas_data(&self) -> &GasData {
         match self {
             Self::V1(v1) => &v1.gas_payment,
-            _ => unimplemented!("a new Transaction variant was added and needs to be handled"),
+            _ => unimplemented!("a new Transaction enum variant was added and needs to be handled"),
         }
     }
 

--- a/product_common/Cargo.toml
+++ b/product_common/Cargo.toml
@@ -23,7 +23,7 @@ async-trait.workspace = true
 bcs = { workspace = true, optional = true }
 cfg-if.workspace = true
 fastcrypto = { workspace = true, optional = true }
-iota-keys = { package = "iota-keys", git = "https://github.com/iotaledger/iota.git", tag = "v1.23.2", optional = true }
+iota-keys = { package = "iota-keys", git = "https://github.com/iotaledger/iota.git", tag = "v1.24.0", optional = true }
 iota-sdk-types = { workspace = true, features = ["serde"] }
 itertools = { version = "0.13.0", optional = true }
 lazy_static = { version = "1.5.0", optional = true }


### PR DESCRIPTION
# Description of change

Following dependencies have been changed:
- [ ] tokio version update to: -
- [ ] fastcrypto version update to rev = "-"
- [x] iota-sdk-types (`https://github.com/iotaledger/iota-rust-sdk.git`) update to rev = cdf7afb2ce3d785f1622711ef1800b18eea391f4
- [x] changes in iota_interaction/src/sdk_types
- [ ] iota_interaction_ts: new peerDep. version for @iota/iota-sdk: _
- [x] pin all iota.git dependencies to `tag = "v1.24.0"`

## Links to any relevant issues

https://github.com/iotaledger/product-core/issues/67

## How the change has been tested

The changes have been tested using IOTA version "v1.24-rc" with the following test PRs:

* Identity: https://github.com/iotaledger/identity/pull/1822
* Notarization: https://github.com/iotaledger/notarization/pull/272