### PR TITLE
Replace wasm-opt in bindings dep with local version

### DIFF
--- a/.github/workflows/shared-build-wasm.yml
+++ b/.github/workflows/shared-build-wasm.yml
@@ -59,6 +59,13 @@ jobs:
         with:
           version: "0.2.108"
 
+      # Install wasm-opt from binaryen repository.
+      - name: Install binaryen
+        uses: sigoden/install-binary@v1
+        with:
+          repo: WebAssembly/binaryen
+          name: wasm-opt
+
       - name: Setup sccache
         uses: "./.github/actions/rust/sccache/setup-sccache"
         with:

--- a/bindings/wasm/iota_interaction_ts/README.md
+++ b/bindings/wasm/iota_interaction_ts/README.md
@@ -1,3 +1,55 @@
 # Web Assembly adapters for iota_interaction
 
 WASM bindings importing types from the IOTA Client typescript SDK to be used in the Rust code of IOTA products.
+
+## Build the Library
+
+Alternatively, you can build the bindings yourself if you have Rust installed. If not, refer
+to [rustup.rs](https://rustup.rs) for the installation.
+
+### Requirements
+
+- [Node.js](https://nodejs.org/en) (>= `v20`)
+- [Rust](https://www.rust-lang.org/) (>= 1.65)
+- [Cargo](https://doc.rust-lang.org/cargo/) (>= 1.65)
+
+### 1. Install Local Tooling
+
+If you want to build the library from source you have to install additional build tools locally.
+
+### Install `wasm-bindgen-cli`
+
+First you need to install [`wasm-bindgen-cli`](https://github.com/rustwasm/wasm-bindgen).
+A manual installation is required because we use the [Weak References](https://rustwasm.github.io/wasm-bindgen/reference/weak-references.html) feature,
+which [`wasm-pack` does not expose](https://github.com/rustwasm/wasm-pack/issues/930).
+
+```bash
+cargo install --force wasm-bindgen-cli
+```
+
+### Install `wasm-opt`
+
+To reduce the size of the wasm package, it is optimized with `wasm-opt`, which is part of [`binaryen`](https://github.com/WebAssembly/binaryen).
+
+You can either download a [release of binaryen](https://github.com/WebAssembly/binaryen/releases) and make the bin folder available in your PATH or check if your operating system tooling offers a more convenient way of installing the binaries like APT, Homebrew, etc.
+
+Some examples:
+
+- Linux via APT: `sudo apt-get update && sudo apt-get -y install binaryen` (taken from [here](https://installati.one/install-binaryen-ubuntu-22-04/))
+- MacOS via Homebrew: `brew install binaryen` (see [Homebrew entry](https://formulae.brew.sh/formula/binaryen))
+
+### 2. Install Dependencies
+
+After installing `wasm-bindgen-cli`, you can install the necessary dependencies using the following command:
+
+```bash
+npm install
+```
+
+### 3. Build
+
+You can build the bindings using the following command:
+
+```bash npm2yarn
+npm run build
+```

--- a/bindings/wasm/iota_interaction_ts/README.md
+++ b/bindings/wasm/iota_interaction_ts/README.md
@@ -17,7 +17,7 @@ to [rustup.rs](https://rustup.rs) for the installation.
 
 If you want to build the library from source you have to install additional build tools locally.
 
-### Install `wasm-bindgen-cli`
+#### Install `wasm-bindgen-cli`
 
 First you need to install [`wasm-bindgen-cli`](https://github.com/rustwasm/wasm-bindgen).
 A manual installation is required because we use the [Weak References](https://rustwasm.github.io/wasm-bindgen/reference/weak-references.html) feature,
@@ -27,7 +27,7 @@ which [`wasm-pack` does not expose](https://github.com/rustwasm/wasm-pack/issues
 cargo install --force wasm-bindgen-cli
 ```
 
-### Install `wasm-opt`
+#### Install `wasm-opt`
 
 To reduce the size of the wasm package, it is optimized with `wasm-opt`, which is part of [`binaryen`](https://github.com/WebAssembly/binaryen).
 
@@ -40,7 +40,7 @@ Some examples:
 
 ### 2. Install Dependencies
 
-After installing `wasm-bindgen-cli`, you can install the necessary dependencies using the following command:
+After installing local tooling, you can install the necessary dependencies using the following command:
 
 ```bash
 npm install

--- a/bindings/wasm/iota_interaction_ts/package-lock.json
+++ b/bindings/wasm/iota_interaction_ts/package-lock.json
@@ -13,8 +13,7 @@
         "dprint": "^0.33.0",
         "rimraf": "^6.0.1",
         "tsconfig-paths": "^4.1.0",
-        "typescript": "^5.7.3",
-        "wasm-opt": "^1.4.0"
+        "typescript": "^5.7.3"
       },
       "engines": {
         "node": ">=20"
@@ -291,15 +290,6 @@
         "node": "*"
       }
     },
-    "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -382,30 +372,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/glob": {
@@ -545,72 +511,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/package-json-from-dist": {
@@ -818,29 +718,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "dev": true,
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
-    },
     "node_modules/tsconfig-paths": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
@@ -888,36 +765,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/wasm-opt": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/wasm-opt/-/wasm-opt-1.4.0.tgz",
-      "integrity": "sha512-wIsxxp0/FOSphokH4VOONy1zPkVREQfALN+/JTvJPK8gFSKbsmrcfECu2hT7OowqPfb4WEMSMceHgNL0ipFRyw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "node-fetch": "^2.6.9",
-        "tar": "^6.1.13"
-      },
-      "bin": {
-        "wasm-opt": "bin/wasm-opt.js"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -1025,12 +872,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/yauzl": {
       "version": "2.10.0",

--- a/bindings/wasm/iota_interaction_ts/package.json
+++ b/bindings/wasm/iota_interaction_ts/package.json
@@ -36,8 +36,7 @@
     "dprint": "^0.33.0",
     "rimraf": "^6.0.1",
     "tsconfig-paths": "^4.1.0",
-    "typescript": "^5.7.3",
-    "wasm-opt": "^1.4.0"
+    "typescript": "^5.7.3"
   },
   "peerDependencies": {
     "@iota/iota-sdk": "^1.14.0"


### PR DESCRIPTION
# Description of change

PR removes outdated `wasm-opt` installed via NPM, and add the requirement to have `wasm-opt` installed locally, which allows using newer versions, that are compatible with the latest Rust toolchain versions.

This solves the `[parse exception: invalid code after misc prefix: 17 (at ...)]` [e.g.](https://github.com/iotaledger/product-core/actions/runs/27129747459/job/80067410859#step:8:601) thrown by `wasm-opt` when building the WASM bindings, which lead to skipping the optimization process.

## Links to any relevant issues

See [related issue](https://github.com/iotaledger/identity/issues/1811).

## Type of change

<!-- Choose a type of change, and delete any options that are not relevant. -->

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Same changes fixed `wasm-opt` error in identity project (see related issue above).

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
